### PR TITLE
BUG: Saving overall mask

### DIFF
--- a/echofilter/raw/manipulate.py
+++ b/echofilter/raw/manipulate.py
@@ -542,6 +542,7 @@ def load_decomposed_transect_mask(
 
     # Determine whether each timestamp is for recording which was completely
     # removed from analysis (but not because it is passive recording)
+    mask = ~np.isnan(signals_mskd)
     allnan = np.all(np.isnan(signals_mskd), axis=1)
     is_removed = allnan & ~is_passive
 


### PR DESCRIPTION
The mask was being modified in-place by `make_lines_from_mask`, which is now fixed. Just in case any functions change and do make in-place modifications, we now re-do the determination of the mask as well.