### PR TITLE
BUG: Save reversed data for upward-facing recordings

### DIFF
--- a/echofilter/raw/manipulate.py
+++ b/echofilter/raw/manipulate.py
@@ -550,9 +550,9 @@ def load_decomposed_transect_mask(
     # Ensure depth is always increasing (which corresponds to descending from
     # the air down the water column)
     if is_upward_facing:
-        depths_raw = depths_raw[::-1]
-        signals_raw = signals_raw[:, ::-1]
-        mask = mask[:, ::-1]
+        depths_raw = depths_raw[::-1].copy()
+        signals_raw = signals_raw[:, ::-1].copy()
+        mask = mask[:, ::-1].copy()
 
     if d_top is None:
         d_top = np.nan * np.ones_like(ts_raw)


### PR DESCRIPTION
Need to return a copy not a view of reversed data to ensure the saved data is also reversed.