### PR TITLE
ENH: Add overall loss term

### DIFF
--- a/echofilter/wrapper.py
+++ b/echofilter/wrapper.py
@@ -78,8 +78,8 @@ class Echofilter(nn.Module):
 
         outputs['p_keep_pixel'] = (
             1.
-            * (1 - outputs['p_is_above_top'])
-            * (1 - outputs['p_is_below_bottom'])
+            * 0.5 * ((1 - outputs['p_is_above_top']) + outputs['p_is_below_top'])
+            * 0.5 * ((1 - outputs['p_is_below_bottom']) + outputs['p_is_above_bottom'])
             * (1 - outputs['p_is_removed'].unsqueeze(-1))
             * (1 - outputs['p_is_passive'].unsqueeze(-1))
             * (1 - outputs['p_is_patch'])


### PR DESCRIPTION
We add an overall loss term.

To prevent P(is above top) and P(is below bottom) leaving the range [0, 1] (due to accumulated floating point rounding with cumsum), we now clamp their values.

For stability, it was necessary to also output a P(is_below_top) term, which uses cumsum in the reverse direction, and then use the average between the two implied values P(is_below_top) from the two cumsums with `0.5 * ( (1 - P(is_above_top)) + P(is_below_top) )`. It appears that computing the overall pixel probability with only one of these cumsum terms is unstable because the cumsum applies too much weighting on one end of the depth range. Using terms created with cumsum in each direction counteracts this, giving equal weighting across all pixel depths.