### PR TITLE
Updated separation scripts

### DIFF
--- a/separate_mobile.sh
+++ b/separate_mobile.sh
@@ -1,16 +1,28 @@
 #!/bin/bash
 
-# Separate all of the survey files into test/train/validate sets
-
 # Use the output from :
 # /data/dsforce/surveyExports/getInfo.sh > files.txt
 
-infile="allFiles.txt"
+
+infile="../allFiles.txt"
 trainfile="train.txt"
 testfile="test.txt"
 valfile="validate.txt"
 restfile="rest.txt"
 tempfile="temp.txt"
+
+myseed="1"
+if [ $# -ge 1 ] ; then
+  myseed="$1"
+fi
+
+get_seeded_random()
+{
+  seed="$1"
+  openssl enc -aes-256-ctr -pass pass:"$seed" -nosalt \
+    </dev/zero 2>/dev/null
+}
+
 
 # Check the number of data points for each file, count how many have that number of data points:
 # cat $infile | awk -F, '{print $3}' | sort | uniq -c > columns.txt
@@ -27,6 +39,7 @@ cat $tempfile | grep -v "_S2" > $restfile
 cat $restfile | grep Winter > winter.txt
 cat $restfile | grep -v Winter > nonwinter.txt
 
+
 total=`cat winter.txt | wc -l`
 testnum=`echo "scale=0;$total / 10" | bc  `
 trainnum=`echo "scale=0;$total - ( 2 * $testnum ) " | bc`
@@ -35,7 +48,7 @@ trainnum=`echo "scale=0;$total - ( 2 * $testnum ) " | bc`
 rm -rf $tempfile
 
 # shuffle, and put enough in each file
-shuf winter.txt > wintershuf.txt
+shuf --random-source=<(get_seeded_random $myseed) winter.txt > wintershuf.txt
 head -n $trainnum wintershuf.txt > $trainfile
 tail -n `echo "scale=0;$testnum * 2" | bc` wintershuf.txt > $tempfile
 tail -n $testnum $tempfile > $valfile
@@ -48,10 +61,11 @@ trainnum=`echo "scale=0;$total - ( 2 * $testnum )" | bc`
 
 rm -rf $tempfile
 
-shuf nonwinter.txt > nonwintershuf.txt
+shuf --random-source=<(get_seeded_random $myseed) nonwinter.txt > nonwintershuf.txt
 head -n $trainnum wintershuf.txt > train.txt
 tail -n `echo "scale=0;$testnum * 2" | bc ` wintershuf.txt > temp.txt
 tail -n $testnum $tempfile > validate.txt
 head -n $testnum $tempfile > test.txt
+
 
 rm -rf $tempfile

--- a/separate_stationary.sh
+++ b/separate_stationary.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+
 # Take a list of dates, and separate them into test/train/validate sets
 #
 # One way to get that list would be something like:
 # for survey in december2017  march2018  september2018 ; do ls -1 $survey/evExports/*.csv ; done | sed "s:-.*::g" >dates.txt
+
+bdir="/data/dsforce/surveyExports/stationary"
+wdir="/data/dsforce/surveyExports/stationary/sets/temp"
 
 infile="dates.txt"
 trainfile="train.txt"
@@ -15,6 +19,19 @@ valdates="date_val.txt"
 tempfile="temp.txt"
 shuffile="shuffle.txt"
 
+myseed="1"
+if [ $# -ge 1 ] ; then
+  myseed="$1"
+fi
+
+get_seeded_random()
+{
+  seed="$1"
+  openssl enc -aes-256-ctr -pass pass:"$seed" -nosalt \
+    </dev/zero 2>/dev/null
+}
+
+
 total=`cat $infile | wc -l`
 testnum=`echo "scale=0;$total / 10" | bc  `
 trainnum=`echo "scale=0;$total - ( 2 * $testnum )" | bc`
@@ -25,7 +42,7 @@ echo "Test  : $testnum"
 rm -rf $tempfile
 
 # shuffle, and put enough in each file
-shuf $infile > $shuffile
+shuf --random-source=<(get_seeded_random $myseed) $infile > $shuffile
 head -n $trainnum $shuffile > $traindates
 tail -n `echo "scale=0;$testnum * 2" | bc` $shuffile > $tempfile
 tail -n $testnum $tempfile > $valdates
@@ -33,6 +50,7 @@ head -n $testnum $tempfile > $testdates
 
 rm -rf $tempfile
 
-for line in `cat $traindates` ; do ls -1 ${line}*.csv ; done > $trainfile
-for line in `cat $testdates` ; do ls -1 ${line}*.csv ; done > $testfile
-for line in `cat $valdates` ; do ls -1 ${line}*.csv ; done > $valfile
+cd $bdir
+for line in `cat $wdir/$traindates` ; do ls -1 ${line}*.csv ; done > $wdir/$trainfile
+for line in `cat $wdir/$testdates` ; do ls -1 ${line}*.csv ; done > $wdir/$testfile
+for line in `cat $wdir/$valdates` ; do ls -1 ${line}*.csv ; done > $wdir/$valfile


### PR DESCRIPTION
These scripts were used to separate the datasets into test/train/validate sets.  They now include a randomization seed that can be passed as a command line argument.