### PR TITLE
ENH: Add new checkpoint

### DIFF
--- a/echofilter/inference.py
+++ b/echofilter/inference.py
@@ -34,6 +34,7 @@ DATA_MEAN = -80.
 DATA_STDEV = 20.
 
 CHECKPOINT_RESOURCES = OrderedDict([
+    ('stationary_effunet_block6.xb.2-1_lc32_se2_v2.ckpt.tar', {'gdrive': '1Rgr6y7SYEYrAq6tSF7tjqbKoZthKpMCb'}),
     ('stationary_effunet_block6.xb.2-1_lc32_se2.ckpt.tar', {'gdrive': '114vL-pAxrn9UDhaNG5HxZwjxNy7WMfW_'}),
 ])
 DEFAULT_CHECKPOINT = next(iter(CHECKPOINT_RESOURCES))


### PR DESCRIPTION
And make the new and improved model be the new default.

The new checkpoint is the same architecture, but trained for 200 epochs instead of 80 epochs. This increases the validation Jaccard Index from 93.5% to 93.9%.