### PR TITLE
BUG: EVL writer needs to output time to nearest 0.1ms

### DIFF
--- a/echofilter/raw/loader.py
+++ b/echofilter/raw/loader.py
@@ -381,9 +381,15 @@ def evl_writer(fname, timestamps, depths, status=1):
         print(n_row, file=hf)
         # Write each row
         for i_row, (timestamp, depth) in enumerate(zip(timestamps, depths)):
+            # Datetime must be in the format CCYYMMDD HHmmSSssss
+            # where ssss = 0.1 milliseconds.
+            # We have to manually determine the number of "0.1 milliseconds"
+            # from the microsecond component.
+            dt = datetime.datetime.fromtimestamp(timestamp)
             print(
-                '{}  {} {} '.format(
-                    datetime.datetime.fromtimestamp(timestamp).strftime('%Y%m%d %H%M%S%f'),
+                '{}{:04d}  {} {} '.format(
+                    dt.strftime('%Y%m%d %H%M%S'),
+                    round(dt.microsecond / 100),
                     depth,
                     0 if i_row == n_row - 1 else status,
                 ),


### PR DESCRIPTION
As per the specification,
https://support.echoview.com/WebHelp/Using_Echoview/Exporting/Exporting_data/Exporting_line_data.htm#Line_definition_file_format
datetime should be recorded as
CCYYMMDD HHmmSSssss
where ssss = 0.1 milliseconds.

Previously we were reporting the timestamp with two extra digits of
precision (to the nearest microsecond), but this is causing a
problem with loading the evl files into Echoview.