### PR TITLE
MNT: Fewer training images

### DIFF
--- a/echofilter/train.py
+++ b/echofilter/train.py
@@ -617,14 +617,6 @@ def train(
                 dataformats="NCWH",
             )
             writer.add_images(
-                "Overall/" + partition + "/Output/mask",
-                ensure_clim_met(
-                    add_image_border(ex_output["mask_keep_pixel"].float().unsqueeze(1))
-                ),
-                epoch,
-                dataformats="NCWH",
-            )
-            writer.add_images(
                 "Overall/" + partition + "/Overlap",
                 ensure_clim_met(
                     add_image_border(


### PR DESCRIPTION
- No need to generate mask output, since we have probabilities and overall (which shows how output mask relates to target mask)
- Generate sample transect plots less often.