### PR TITLE
BUG: Disable thresholds for ev2csv export

### DIFF
--- a/echofilter/ev2csv.py
+++ b/echofilter/ev2csv.py
@@ -224,6 +224,10 @@ def ev2csv(
         av.Properties.Analysis.ExcludeBelow = "None"
         av.Properties.Analysis.ExcludeBadDataRegions = False
         av.Properties.Analysis.ExcludeBadLineStatusPings = False
+        av.Properties.Data.ApplyMinimumThreshold = False
+        av.Properties.Data.ApplyMaximumThreshold = False
+        av.Properties.Data.ApplyMinimumTsThreshold = False
+        av.Properties.Data.ApplyTimeVariedThreshold = False
 
         # Export the raw file
         if verbose >= 1:


### PR DESCRIPTION
Need to disable more thresholds to ensure the raw data is output.

Using settings documented here:
https://support.echoview.com/WebHelp/How_to/Run_Echoview_using_scripts/COM_objects/COM_object_EvAnalysis.htm
https://support.echoview.com/WebHelp/How_to/Run_Echoview_using_scripts/COM_objects/COM_object_EvData.htm