### PR TITLE
MNT: Change GrandPassage sample transect

### DIFF
--- a/echofilter/train.py
+++ b/echofilter/train.py
@@ -82,8 +82,8 @@ PLOT_TRANSECTS = {
         "MinasPassage/september2018/evExports/september2018_D20181107-T122220_D20181107-T175217",
     ],
     "GrandPassage": [
-        "GrandPassage/phase1/GrandPassage_WBAT_2A_20191222",
         "GrandPassage/phase2/GrandPassage_WBAT_2B_20200125_UTC160020_ebblow",
+        "GrandPassage/phase2/GrandPassage_WBAT_2B_20200202_UTC040019_floodhigh",
     ],
 }
 


### PR DESCRIPTION
This change reflects the change in the GrandPassage partitions
so that the paired labelled data is in the test partition.