### PR TITLE
BUG: Ensure index for xent is in bounds

### DIFF
--- a/echofilter/dataset.py
+++ b/echofilter/dataset.py
@@ -363,7 +363,7 @@ class TransectDataset(torch.utils.data.Dataset):
             # It is possible for the top line to be above the field of view,
             # and impossible for the top line to below
             sample["index_" + sfx] = np.maximum(
-                0, np.minimum(len(sample["depths"]), sample["index_" + sfx])
+                0, np.minimum(len(sample["depths"]) - 1, sample["index_" + sfx])
             )
         for sfx in {"bot", "bot-original"}:
             # Ties are broken to the larger index
@@ -374,7 +374,7 @@ class TransectDataset(torch.utils.data.Dataset):
             # and impossible for the bottom line to above
             sample["index_" + sfx] -= 1
             sample["index_" + sfx] = np.maximum(
-                0, np.minimum(len(sample["depths"]), sample["index_" + sfx])
+                0, np.minimum(len(sample["depths"]) - 1, sample["index_" + sfx])
             )
 
         # Ensure everything is float32 datatype


### PR DESCRIPTION
This appears to have been the cause of miscellaneous CUDA memory errors, which appear as
```
THCudaCheck FAIL file=<conda>/work/aten/src/THC/THCTensorMathCompareT.cuh line=69 error=700 : an illegal memory access was encountered
loss_term: Traceback (most recent call last):
  File "<package>/nn/wrapper.py", line 467, in forward
    if torch.isnan(loss_term).any():
RuntimeError: CUDA error: an illegal memory access was encountered
```
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
<trimmed>
  File "<venv>/python3.6/site-packages/torch/tensor.py", line 82, in __repr__
    return torch._tensor_str._str(self)
  File "<venv>/python3.6/site-packages/torch/_tensor_str.py", line 300, in _str
    tensor_str = _tensor_str(self, indent)
  File "<venv>/python3.6/site-packages/torch/_tensor_str.py", line 201, in _tensor_str
    formatter = _Formatter(get_summarized_data(self) if summarize else self)
  File "<venv>/python3.6/site-packages/torch/_tensor_str.py", line 83, in __init__
    value_str = '{}'.format(value)
  File "<venv>/python3.6/site-packages/torch/tensor.py", line 340, in __format__
    return self.item().__format__(format_spec)
RuntimeError: CUDA error: an illegal memory access was encountered
```
and
```
Traceback (most recent call last):
<trimmed>
  File "<package>/train.py", line 1031, in train_epoch
    scaled_loss.backward()
  File "<venv>/python3.6/site-packages/torch/tensor.py", line 118, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph)
  File "<venv>/python3.6/site-packages/torch/autograd/__init__.py", line 93, in backward
    allow_unreachable=True)  # allow_unreachable flag
RuntimeError: copy_if failed to synchronize: cudaErrorIllegalAddress: an illegal memory access was encountered
```

When running with `CUDA_LAUNCH_BLOCKING=1`, this appears as:
```
Traceback (most recent call last):
<trimmed>
  File "<package>/nn/wrapper.py", line 450, in forward
    loss_term = loss_term * my_loss_inc_mask
  File "<venv>/lib/python3.6/site-packages/apex/amp/wrap.py", line 57, in wrapper
    kwargs)
  File "<venv>/lib/python3.6/site-packages/apex/amp/utils.py", line 78, in casted_args
    new_args.append(cast_fn(x))
  File "<venv>/lib/python3.6/site-packages/apex/amp/utils.py", line 71, in maybe_float
    return x.float()
RuntimeError: CUDA error: an illegal memory access was encountered
```
and
```
THCudaCheck FAIL file=<conda>/work/aten/src/ATen/native/cuda/SoftMax.cu line=646 error=700 : an illegal memory access was encountered
Traceback (most recent call last):
<trimmed>
  File "<package>/train.py", line 1042, in train_epoch
    scaled_loss.backward()
  File "<venv>/lib/python3.6/site-packages/torch/tensor.py", line 118, in backward
    torch.autograd.backward(self, gradient, retain_graph, create_graph)
  File "<venv>/lib/python3.6/site-packages/torch/autograd/__init__.py", line 93, in backward
    allow_unreachable=True)  # allow_unreachable flag
RuntimeError: cuda runtime error (700) : an illegal memory access was encountered at <conda>/work/aten/src/ATen/native/cuda/SoftMax.cu:646
```
and
```
Traceback (most recent call last):
<trimmed>
  File "<package>/nn/wrapper.py", line 444, in forward
    loss_term = F.cross_entropy(
  File "<venv>/lib/python3.6/site-packages/apex/amp/wrap.py", line 53, in wrapper
    return orig_fn(*args, **kwargs)
RuntimeError: CUDA error: an illegal memory access was encountered
```
and
```
Traceback (most recent call last):
<trimmed>
  File "<package>/train.py", line 1042, in train_epoch
    scaled_loss.backward()
  File "<venv>/lib/python3.6/contextlib.py", line 88, in __exit__
    next(self.gen)
  File "<venv>/lib/python3.6/site-packages/apex/amp/handle.py", line 124, in scale_loss
    should_skip = False if delay_overflow_check else loss_scaler.update_scale()
  File "<venv>/lib/python3.6/site-packages/apex/amp/scaler.py", line 200, in update_scale
    self._has_overflow = self._overflow_buf.item()
RuntimeError: CUDA error: an illegal memory access was encountered
```

It is possible that some of these errors were due to something else and were resolved elsewhere (#115).

The presence of `cross_entropy` directed me toward this culprit.

The error occurred only occasionally, since it requires one of the lines to be at a deeper depth than the field of view. This is not possible for the top line due to the way the cropping was performed, and is only possible for the the surface line if it ventures below the top line (which means malformed training data).