### PR TITLE
MNT: Reseeding random state

### DIFF
--- a/echofilter/train.py
+++ b/echofilter/train.py
@@ -140,6 +140,10 @@ def train(
 ):
 
     seed_all(seed)
+    # Can't get this to be deterministic anyway, so may as well keep the
+    # non-deterministic optimization enabled
+    torch.backends.cudnn.deterministic = False
+    torch.backends.cudnn.benchmark = True
 
     # Input handling
     schedule = schedule.lower()
@@ -387,6 +391,10 @@ def train(
         # exact initial augmented samples from the first epoch again when
         # resuming later in the run)
         seed_all(1000 + seed + epoch)
+        # Can't get this to be deterministic anyway, so may as well keep the
+        # non-deterministic optimization enabled
+        torch.backends.cudnn.deterministic = False
+        torch.backends.cudnn.benchmark = True
 
         # Resample offsets for each window
         loader_train.dataset.initialise_datapoints()


### PR DESCRIPTION
Now re-seed the random state at the start of each epoch, to get consistency between runs and resumed runs from a checkpoint file.

We also give up on complete consistency, and disable determinism for cudnn for extra speed.