### PR TITLE
MNT: Include lines during passive as targets

### DIFF
--- a/echofilter/nn/wrapper.py
+++ b/echofilter/nn/wrapper.py
@@ -310,9 +310,9 @@ class EchofilterLoss(_Loss):
         overall=0.0,
         surface=1.0,
         auxiliary=1.0,
-        ignore_lines_during_passive=True,
+        ignore_lines_during_passive=False,
         ignore_lines_during_removed=True,
-        ignore_surf_during_passive=True,
+        ignore_surf_during_passive=False,
         ignore_surf_during_removed=False,
     ):
         super(EchofilterLoss, self).__init__(None, None, reduction)


### PR DESCRIPTION
Contrary to #92, I think it is actually better to include targets for top/bottom/surface lines during passive recordings. This is because we want the lines to be well behaved during passive regions for the rare cases that we can't cut them out from our output.

We still exclude removed regions from the loss for top and bottom lines though, as these have not been adjusted to accurate depths.

Also refactor the code for this.