### PR TITLE
BUG: Need to add warning filter before importing matplotlib

### DIFF
--- a/bin/inference.py
+++ b/bin/inference.py
@@ -17,8 +17,9 @@ torch.jit.script = script
 
 if __name__ == "__main__":
     import warnings
-    import echofilter.inference
 
     warnings.filterwarnings("ignore", "(?s).*MATPLOTLIBDATA.*", category=UserWarning)
+
+    import echofilter.inference
 
     echofilter.inference.main()


### PR DESCRIPTION
Preventing warning from appearing when running from the exe compiled with pyinstaller.