### PR TITLE
BUG: autocrop with upward facing data

### DIFF
--- a/echofilter/inference.py
+++ b/echofilter/inference.py
@@ -1209,6 +1209,11 @@ def inference_transect(
         # surrounding content.
         new_crop_max += max(2, 10 * depth_intv)
 
+    if crop_depth_min is not None:
+        new_crop_min = max(new_crop_min, crop_depth_min)
+    if crop_depth_max is not None:
+        new_crop_max = min(new_crop_max, crop_depth_max)
+
     current_height = abs(transect["depths"][-1] - transect["depths"][0])
     new_height = abs(new_crop_max - new_crop_min)
     if (current_height - new_height) / current_height <= autocrop_threshold:


### PR DESCRIPTION
Passing data already reflected in the depth dimension was confusing the model and resulting in:
- the data being read in upside down if facing was specified
- the model being put through the wrong conditional model if facing was not specified

This is resolved by passing the original `inference_transect` arguments to its subcall, and not the pre-reflected copy of the data.

This means we need to handle meeting `crop_depth_min` and `crop_depth_max` limits separately.