### PR TITLE
API: Stable default checkpoint

### DIFF
--- a/echofilter/inference.py
+++ b/echofilter/inference.py
@@ -2253,10 +2253,8 @@ def main():
         help="""d|
             Name of checkpoint to load, or path to a checkpoint
             file.
-            Default: "{}".
-        """.format(
-            DEFAULT_CHECKPOINT
-        ),
+            Default: "%(default)s".
+        """,
     )
     group_model.add_argument(
         "--unconditioned",


### PR DESCRIPTION
This reverts commit e5640aa, which was introduced by #147.

The default checkpoint is now always the same again.