### PR TITLE
BUG: Precision with 0 predicted +ve depends on num true +ve

### DIFF
--- a/echofilter/optim/criterions.py
+++ b/echofilter/optim/criterions.py
@@ -70,8 +70,9 @@ def mask_precision(input, target, threshold=0.5, ndim=None, reduction="mean"):
     true_p = (input & target).sum(-1)
     predicted_p = input.sum(-1)
     output = true_p.float() / predicted_p.float()
-    # Handle division by 0: If there were no positives predicted, use 0.5.
-    output[predicted_p == 0] = 0.5
+    # Handle division by 0: If there were no positives predicted, check whether
+    # there were any to find.
+    output[predicted_p == 0] = (true_p[predicted_p == 0] == 0).float()
 
     # Apply reduction
     if reduction == "none":


### PR DESCRIPTION
If there are no true positives, give a precision of 100%; if there were some true positives, give a precision of 0%.