### PR TITLE
BUG: Downfacing nearfield misplaced

### DIFF
--- a/echofilter/inference.py
+++ b/echofilter/inference.py
@@ -959,7 +959,7 @@ def run_inference(
                 if cutoff_at_nearfield:
                     bottom_depths = np.minimum(bottom_depths, nearfield_depth)
             else:
-                nearfield_depth = nearfield
+                nearfield_depth = np.min(depths) + nearfield
                 if cutoff_at_nearfield:
                     turbulence_depths = np.maximum(turbulence_depths, nearfield_depth)
 

--- a/echofilter/ui/inference_cli.py
+++ b/echofilter/ui/inference_cli.py
@@ -546,8 +546,9 @@ def cli():
         default=1.7,
         help="""
             Nearfield distance, in metres. Default: %(default)s.
-            If the echogram is downward facing, the nearfield cutoff depth
-            will be at a depth equal to the nearfield distance.
+            If the echogram is downward facing, the nearfield cutoff will be
+            NEARFIELD meters below the shallowest depth recorded in the input
+            data.
             If the echogram is upward facing, the nearfield cutoff will be
             NEARFIELD meters above the deepest depth recorded in the input
             data.


### PR DESCRIPTION
Since the echosounder is on the boat and elevated above sealevel, the nearfield line should be nearfield meters away from the shallowest recording depth, not at a depth equal to nearfield meters.