### PR TITLE
DEV: Upgrade black 21.12b0 -> 22.10.0 to fix click>8.0.4 issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.10.0
     hooks:
       - id: black
         args:

--- a/echofilter/ui/checkpoints.py
+++ b/echofilter/ui/checkpoints.py
@@ -354,7 +354,7 @@ def load_checkpoint(
                 import shutil
 
                 _, _, free_B = shutil.disk_usage("/")
-                free_MiB = free_B // 10 ** 6
+                free_MiB = free_B // 10**6
 
                 if free_MiB < 64:
                     msg = (

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-black
+black==22.10.0
 nbstripout
 pre-commit


### PR DESCRIPTION
Upgrade black to 22.10.0. This was necessary because click>=8.0.5 broke black<22.3.0.

For details on the issue, see: https://github.com/scottclowe/python-template-repo/pull/101