### PR TITLE
MNT: Look for checkpoints.yaml in parent dir too

### DIFF
--- a/echofilter/ui/checkpoints.py
+++ b/echofilter/ui/checkpoints.py
@@ -14,7 +14,9 @@ from . import style
 
 
 PACKAGE_DIR = os.path.dirname(os.path.dirname(__file__))
+REPO_DIR = os.path.dirname(PACKAGE_DIR)
 CHECKPOINT_FILE = os.path.join(PACKAGE_DIR, "checkpoints.yaml")
+CHECKPOINT_FILE_ALT = os.path.join(REPO_DIR, "checkpoints.yaml")
 CHECKPOINT_EXT = ".pt"
 
 
@@ -28,7 +30,14 @@ def get_checkpoint_list():
         Dictionary with a key for each checkpoint. Each key maps to a dictionary
         whose elements describe the checkpoint.
     """
-    with open(CHECKPOINT_FILE, "r") as hf:
+    checkpoint_file_use = None
+    if os.path.isfile(CHECKPOINT_FILE):
+        checkpoint_file_use = CHECKPOINT_FILE
+    elif os.path.isfile(CHECKPOINT_FILE_ALT):
+        checkpoint_file_use = CHECKPOINT_FILE_ALT
+    else:
+        raise EnvironmentError(f"No such file: '{CHECKPOINT_FILE}'")
+    with open(checkpoint_file_use, "r") as hf:
         checkpoints = OrderedDict(yaml.safe_load(hf)["checkpoints"])
     return checkpoints
 


### PR DESCRIPTION
This is useful for the built exe, which can have checkpoints.yaml alongside the echofilter.exe and not in an echofilter subdirectory.