### PR TITLE
REL: Drop ranger as a hard requirement

### DIFF
--- a/echofilter/train.py
+++ b/echofilter/train.py
@@ -140,7 +140,7 @@ def train(
     n_epoch=20,
     seed=None,
     print_freq=50,
-    optimizer="rangerva",
+    optimizer="adam",
     schedule="constant",
     lr=0.1,
     momentum=0.9,

--- a/requirements-train.txt
+++ b/requirements-train.txt
@@ -1,5 +1,4 @@
 apex
 seaborn
 tensorboard
-ranger @ git+https://github.com/lessw2020/Ranger-Deep-Learning-Optimizer.git@8d636a560b71e740e9423aa10ba4c7f751bb9120#egg=ranger
 torch_lr_finder>=0.2.0


### PR DESCRIPTION
The default optimizer is changed to ADAM. You can still use Ranger, but will need to install it first. It's no longer in requirements-train.txt because we can't specify git repos as requirements for PyPI releases.