### PR TITLE
ENH: Add args to control if CSV export is raw or thresholded

### DIFF
--- a/echofilter/ev2csv.py
+++ b/echofilter/ev2csv.py
@@ -416,7 +416,8 @@ def get_parser():
 
     # Processing arguments
     group_inproc = parser.add_argument_group(
-        "Processing arguments", "Optional parameters specifying how to process files.",
+        "Processing arguments",
+        "Optional parameters specifying how to process files.",
     )
     group_inproc.add_argument(
         "--keep-exclusions",

--- a/echofilter/inference.py
+++ b/echofilter/inference.py
@@ -111,6 +111,7 @@ def run_inference(
     minimum_patch_area=-1,
     patch_mode=None,
     variable_name=DEFAULT_VARNAME,
+    export_raw_csv=True,
     row_len_selector="mode",
     facing="auto",
     use_training_standardization=False,
@@ -381,6 +382,11 @@ def run_inference(
     variable_name : str, optional
         Name of the Echoview acoustic variable to load from EV files. Default
         is `"Fileset1: Sv pings T1"`.
+    export_raw_csv : bool, optional
+        If `True` (default), exclusion and threshold settings in the EV file
+        are temporarily disabled before exporting the CSV, in order to ensure
+        all raw data is exported. If `False`, thresholds and exclusions are
+        used as per the EV file.
     row_len_selector : str, optional
         Method used to handle input csv files with different number of Sv
         values across time (i.e. a non-rectangular input). Default is `"mode"`.
@@ -815,6 +821,7 @@ def run_inference(
                         fname_full,
                         csv_fname,
                         variable_name=variable_name,
+                        export_raw=export_raw_csv,
                         ev_app=ev_app,
                         verbose=verbose - 1,
                     )

--- a/echofilter/ui/inference_cli.py
+++ b/echofilter/ui/inference_cli.py
@@ -797,6 +797,17 @@ def get_parser():
         """,
     )
     group_inproc.add_argument(
+        "--keep-exclusions",
+        "--keep-thresholds",
+        dest="export_raw_csv",
+        action="store_false",
+        help="""
+            Export CSV with all thresholds, exclusion regions, and bad data
+            exclusions set as per the EV file. Default behavior is to
+            ignore these settings and export the underlying raw data.
+        """,
+    )
+    group_inproc.add_argument(
         "--row-len-selector",
         type=str,
         choices=["init", "min", "max", "median", "mode"],


### PR DESCRIPTION
- ev2csv: Add the option to export the raw data in the ev file to the csv file. The default filename changes based on this option.
- ev2csv: Change behaviour to be to export the raw Sv data.
- inference: Use the raw csv as input to inference, not the original export.