### PR TITLE
ENH: Pad transect during inference

### DIFF
--- a/echofilter/inference.py
+++ b/echofilter/inference.py
@@ -28,7 +28,7 @@ from echofilter.nn.unet import UNet
 from echofilter.nn.wrapper import Echofilter
 import echofilter.path
 import echofilter.raw
-from echofilter.raw.manipulate import join_transect, split_transect
+from echofilter.raw.manipulate import join_transect, pad_transect, split_transect
 from echofilter.raw.utils import fillholes2d
 import echofilter.ui
 import echofilter.ui.checkpoints
@@ -1297,6 +1297,7 @@ def inference_transect(
             ]
         )
         segment = transform(segment)
+        segment = pad_transect(segment)
         input = torch.tensor(segment["signals"]).unsqueeze(0).unsqueeze(0)
         input = input.to(device, dtype).contiguous()
         # Put data through model

--- a/echofilter/inference.py
+++ b/echofilter/inference.py
@@ -1297,6 +1297,8 @@ def inference_transect(
             ]
         )
         segment = transform(segment)
+        # Pad the edges of the segment with extra data. Any padding we add
+        # now will be stripped away from the output by join_transect later.
         segment = pad_transect(segment)
         input = torch.tensor(segment["signals"]).unsqueeze(0).unsqueeze(0)
         input = input.to(device, dtype).contiguous()


### PR DESCRIPTION
Pad with more timepoints before and after the sample, then crop them away from the output. This means the outputs don't get reduced quality in their outputs at the edge of the input.

The padding is automatically stripped away from the output by join_transect.