### PR TITLE
TST: Check EVL lines generated are correct

### DIFF
--- a/echofilter/tests/test_inference.py
+++ b/echofilter/tests/test_inference.py
@@ -141,81 +141,87 @@ class test_run_inference(BaseTestCase):
 
     def test_run_downfacing(self):
         with tempfile.TemporaryDirectory() as outdirname:
+            test_fname = self.testfile_downfacing
             inference.run_inference(
                 self.testfile_downfacing,
                 source_dir=self.resource_directory,
                 output_dir=outdirname,
             )
-            basefile = os.path.splitext(self.testfile_downfacing)[0]
+            basefile = os.path.splitext(test_fname)[0]
             self.assert_file_exists(os.path.join(outdirname, basefile + ".bottom.evl"))
             self.assert_file_exists(os.path.join(outdirname, basefile + ".surface.evl"))
             self.assert_file_exists(
                 os.path.join(outdirname, basefile + ".turbulence.evl")
             )
             self.assert_file_exists(os.path.join(outdirname, basefile + ".regions.evr"))
-            self.check_lines(self.testfile_downfacing, outdirname)
+            self.check_lines(test_fname, outdirname)
 
     def test_run_upfacing(self):
         with tempfile.TemporaryDirectory() as outdirname:
+            test_fname = self.testfile_upfacing
             inference.run_inference(
-                self.testfile_upfacing,
+                test_fname,
                 source_dir=self.resource_directory,
                 output_dir=outdirname,
             )
-            basefile = os.path.splitext(self.testfile_upfacing)[0]
+            basefile = os.path.splitext(test_fname)[0]
             self.assert_file_exists(os.path.join(outdirname, basefile + ".bottom.evl"))
             self.assert_file_exists(os.path.join(outdirname, basefile + ".surface.evl"))
             self.assert_file_exists(
                 os.path.join(outdirname, basefile + ".turbulence.evl")
             )
             self.assert_file_exists(os.path.join(outdirname, basefile + ".regions.evr"))
-            self.check_lines(self.testfile_upfacing, outdirname)
+            self.check_lines(test_fname, outdirname)
 
     def test_noclobber_bottom(self):
         with tempfile.TemporaryDirectory() as outdirname:
-            basefile = os.path.splitext(self.testfile_upfacing)[0]
+            test_fname = self.testfile_upfacing
+            basefile = os.path.splitext(test_fname)[0]
             fname = os.path.join(outdirname, basefile + ".bottom.evl")
             pathlib.Path(fname).touch()
             with pytest.raises(EnvironmentError):
                 inference.run_inference(
-                    self.testfile_upfacing,
+                    test_fname,
                     source_dir=self.resource_directory,
                     output_dir=outdirname,
                 )
 
     def test_noclobber_surface(self):
         with tempfile.TemporaryDirectory() as outdirname:
-            basefile = os.path.splitext(self.testfile_upfacing)[0]
+            test_fname = self.testfile_upfacing
+            basefile = os.path.splitext(test_fname)[0]
             fname = os.path.join(outdirname, basefile + ".surface.evl")
             pathlib.Path(fname).touch()
             with pytest.raises(EnvironmentError):
                 inference.run_inference(
-                    self.testfile_upfacing,
+                    test_fname,
                     source_dir=self.resource_directory,
                     output_dir=outdirname,
                 )
 
     def test_noclobber_turbulence(self):
         with tempfile.TemporaryDirectory() as outdirname:
-            basefile = os.path.splitext(self.testfile_upfacing)[0]
+            test_fname = self.testfile_upfacing
+            basefile = os.path.splitext(test_fname)[0]
             fname = os.path.join(outdirname, basefile + ".turbulence.evl")
             pathlib.Path(fname).touch()
             with pytest.raises(EnvironmentError):
                 inference.run_inference(
-                    self.testfile_upfacing,
+                    test_fname,
                     source_dir=self.resource_directory,
                     output_dir=outdirname,
                 )
 
     def test_rerun_skip(self):
         with tempfile.TemporaryDirectory() as outdirname:
-            basefile = os.path.splitext(self.testfile_upfacing)[0]
+            test_fname = self.testfile_upfacing
+            basefile = os.path.splitext(test_fname)[0]
             pathlib.Path(os.path.join(outdirname, basefile + ".bottom.evl")).touch()
             pathlib.Path(os.path.join(outdirname, basefile + ".surface.evl")).touch()
             pathlib.Path(os.path.join(outdirname, basefile + ".turbulence.evl")).touch()
             pathlib.Path(os.path.join(outdirname, basefile + ".regions.evr")).touch()
             inference.run_inference(
-                self.testfile_upfacing,
+                test_fname,
                 source_dir=self.resource_directory,
                 output_dir=outdirname,
                 skip_existing=True,
@@ -223,28 +229,30 @@ class test_run_inference(BaseTestCase):
 
     def test_rerun_overwrite(self):
         with tempfile.TemporaryDirectory() as outdirname:
-            basefile = os.path.splitext(self.testfile_upfacing)[0]
+            test_fname = self.testfile_upfacing
+            basefile = os.path.splitext(test_fname)[0]
             pathlib.Path(os.path.join(outdirname, basefile + ".bottom.evl")).touch()
             pathlib.Path(os.path.join(outdirname, basefile + ".surface.evl")).touch()
             pathlib.Path(os.path.join(outdirname, basefile + ".turbulence.evl")).touch()
             pathlib.Path(os.path.join(outdirname, basefile + ".regions.evr")).touch()
             inference.run_inference(
-                self.testfile_upfacing,
+                test_fname,
                 source_dir=self.resource_directory,
                 output_dir=outdirname,
                 overwrite_existing=True,
             )
-            self.check_lines(self.testfile_upfacing, outdirname)
+            self.check_lines(test_fname, outdirname)
 
     def test_no_bottom(self):
         with tempfile.TemporaryDirectory() as outdirname:
+            test_fname = self.testfile_upfacing
             inference.run_inference(
-                self.testfile_upfacing,
+                test_fname,
                 source_dir=self.resource_directory,
                 output_dir=outdirname,
                 generate_bottom_line=False,
             )
-            basefile = os.path.splitext(self.testfile_upfacing)[0]
+            basefile = os.path.splitext(test_fname)[0]
             self.assert_file_absent(os.path.join(outdirname, basefile + ".bottom.evl"))
             self.assert_file_exists(os.path.join(outdirname, basefile + ".surface.evl"))
             self.assert_file_exists(
@@ -254,13 +262,14 @@ class test_run_inference(BaseTestCase):
 
     def test_no_surface(self):
         with tempfile.TemporaryDirectory() as outdirname:
+            test_fname = self.testfile_upfacing
             inference.run_inference(
-                self.testfile_upfacing,
+                test_fname,
                 source_dir=self.resource_directory,
                 output_dir=outdirname,
                 generate_surface_line=False,
             )
-            basefile = os.path.splitext(self.testfile_upfacing)[0]
+            basefile = os.path.splitext(test_fname)[0]
             self.assert_file_exists(os.path.join(outdirname, basefile + ".bottom.evl"))
             self.assert_file_absent(os.path.join(outdirname, basefile + ".surface.evl"))
             self.assert_file_exists(
@@ -270,13 +279,14 @@ class test_run_inference(BaseTestCase):
 
     def test_no_turbulence(self):
         with tempfile.TemporaryDirectory() as outdirname:
+            test_fname = self.testfile_upfacing
             inference.run_inference(
-                self.testfile_upfacing,
+                test_fname,
                 source_dir=self.resource_directory,
                 output_dir=outdirname,
                 generate_turbulence_line=False,
             )
-            basefile = os.path.splitext(self.testfile_upfacing)[0]
+            basefile = os.path.splitext(test_fname)[0]
             self.assert_file_exists(os.path.join(outdirname, basefile + ".bottom.evl"))
             self.assert_file_exists(os.path.join(outdirname, basefile + ".surface.evl"))
             self.assert_file_absent(
@@ -286,13 +296,14 @@ class test_run_inference(BaseTestCase):
 
     def test_with_patches(self):
         with tempfile.TemporaryDirectory() as outdirname:
+            test_fname = self.testfile_upfacing
             inference.run_inference(
-                self.testfile_upfacing,
+                test_fname,
                 source_dir=self.resource_directory,
                 output_dir=outdirname,
                 minimum_patch_area=25,
             )
-            basefile = os.path.splitext(self.testfile_upfacing)[0]
+            basefile = os.path.splitext(test_fname)[0]
             self.assert_file_exists(os.path.join(outdirname, basefile + ".bottom.evl"))
             self.assert_file_exists(os.path.join(outdirname, basefile + ".surface.evl"))
             self.assert_file_exists(
@@ -302,13 +313,14 @@ class test_run_inference(BaseTestCase):
 
     def test_with_logitsmoothing(self):
         with tempfile.TemporaryDirectory() as outdirname:
+            test_fname = self.testfile_upfacing
             inference.run_inference(
-                self.testfile_upfacing,
+                test_fname,
                 source_dir=self.resource_directory,
                 output_dir=outdirname,
                 logit_smoothing_sigma=2,
             )
-            basefile = os.path.splitext(self.testfile_upfacing)[0]
+            basefile = os.path.splitext(test_fname)[0]
             self.assert_file_exists(os.path.join(outdirname, basefile + ".bottom.evl"))
             self.assert_file_exists(os.path.join(outdirname, basefile + ".surface.evl"))
             self.assert_file_exists(
@@ -318,13 +330,14 @@ class test_run_inference(BaseTestCase):
 
     def test_run_verbose(self):
         with tempfile.TemporaryDirectory() as outdirname:
+            test_fname = self.testfile_upfacing
             inference.run_inference(
-                self.testfile_upfacing,
+                test_fname,
                 source_dir=self.resource_directory,
                 output_dir=outdirname,
                 verbose=10,
             )
-            basefile = os.path.splitext(self.testfile_upfacing)[0]
+            basefile = os.path.splitext(test_fname)[0]
             self.assert_file_exists(os.path.join(outdirname, basefile + ".bottom.evl"))
             self.assert_file_exists(os.path.join(outdirname, basefile + ".surface.evl"))
             self.assert_file_exists(
@@ -334,13 +347,14 @@ class test_run_inference(BaseTestCase):
 
     def test_run_quiet(self):
         with tempfile.TemporaryDirectory() as outdirname:
+            test_fname = self.testfile_upfacing
             inference.run_inference(
-                self.testfile_upfacing,
+                test_fname,
                 source_dir=self.resource_directory,
                 output_dir=outdirname,
                 verbose=0,
             )
-            basefile = os.path.splitext(self.testfile_upfacing)[0]
+            basefile = os.path.splitext(test_fname)[0]
             self.assert_file_exists(os.path.join(outdirname, basefile + ".bottom.evl"))
             self.assert_file_exists(os.path.join(outdirname, basefile + ".surface.evl"))
             self.assert_file_exists(

--- a/echofilter/tests/test_inference.py
+++ b/echofilter/tests/test_inference.py
@@ -23,6 +23,7 @@ import pathlib
 import tempfile
 
 import pytest
+from parametrize import parametrize
 
 from .. import inference
 from ..raw.loader import evl_loader
@@ -139,26 +140,9 @@ class test_run_inference(BaseTestCase):
             dry_run=True,
         )
 
-    def test_run_downfacing(self):
+    @parametrize("test_fname", EXPECTED_STATS.keys())
+    def test_run_files(self, test_fname):
         with tempfile.TemporaryDirectory() as outdirname:
-            test_fname = self.testfile_downfacing
-            inference.run_inference(
-                self.testfile_downfacing,
-                source_dir=self.resource_directory,
-                output_dir=outdirname,
-            )
-            basefile = os.path.splitext(test_fname)[0]
-            self.assert_file_exists(os.path.join(outdirname, basefile + ".bottom.evl"))
-            self.assert_file_exists(os.path.join(outdirname, basefile + ".surface.evl"))
-            self.assert_file_exists(
-                os.path.join(outdirname, basefile + ".turbulence.evl")
-            )
-            self.assert_file_exists(os.path.join(outdirname, basefile + ".regions.evr"))
-            self.check_lines(test_fname, outdirname)
-
-    def test_run_upfacing(self):
-        with tempfile.TemporaryDirectory() as outdirname:
-            test_fname = self.testfile_upfacing
             inference.run_inference(
                 test_fname,
                 source_dir=self.resource_directory,

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
+parametrize
 pytest>=3.5.0
 pytest-cov


### PR DESCRIPTION
Check the EVL files generated have the correct number of values in them, and have the expected range of depth values for each line.