### PR TITLE
REL: Fix max requirements specification

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: "3.7"
-            frozen: True
+            frozen: "frozen"
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7"]
+        python-version: ["3.6", "3.10"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.7"
+            frozen: True
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
@@ -50,13 +54,19 @@ jobs:
         key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
         restore-keys: ${{ runner.os }}-pip-
 
-    - name: Install dependencies
+    - name: Install common dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8
+
+    - name: Install frozen dependencies
+      if: ${{ matrix.frozen }}
+      run: |
         python -m pip install torch==1.4.0+cpu torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
         python -m pip install -r frozen_requirements.txt
-        python -m pip install .[test]
+
+    - name: Install package
+      run: python -m pip install .[test]
 
     - name: Get appdirs cache dir
       id: appdirs-cache

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.10"]
+        python-version: ["3.10"]
         include:
           - os: ubuntu-latest
             python-version: "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ pywin32; platform_system=="Windows"
 pyyaml
 scikit-image
 scipy
-torch
-torchvision
+torch<1.12.0
+torchvision<0.13.0
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ class PyTest(TestCommand):
 setup(
     # Essential details on the package and its dependencies
     name=meta["name"],
-    python_requires=">=3.6",
+    python_requires=">=3.6,<3.11",
     version=meta["version"],
     packages=find_packages(exclude=["tests", "*.tests", "*.tests.*", "tests.*"]),
     package_dir={meta["name"]: os.path.join(".", meta["path"])},


### PR DESCRIPTION
The code is breaking on torch==1.12.0. It is not yet clear what the source of the error is.

Since our maximum version of pytorch only support python<=3.10, we can't possibly support anything above this.
