### PR TITLE
CI: Fix Codecov reports

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,7 @@ jobs:
         python -m pytest --cov=echofilter --cov-report term --cov-report xml --cov-config .coveragerc --junitxml=testresults.xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         flags: unittests
         env_vars: OS,PYTHON

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,6 +86,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests
         env_vars: OS,PYTHON
         name: Python ${{ matrix.python-version }} on ${{ runner.os }}


### PR DESCRIPTION
Need to upgrade the action from v1 to v3 (apparently v1 has been discontinued).
Also, there is a bug which is preventing public repos from being automatically detected correctly, so we have to manually add and send the Codecov secret token (https://github.com/codecov/codecov-action/issues/557).