### PR TITLE
REL: Add requests to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ numpy
 pandas
 pywin32; platform_system=="Windows"
 pyyaml
+requests
 scikit-image
 scipy
 torch<1.12.0


### PR DESCRIPTION
We did not encounter the fact this was missing before because checkpoints had been cached when building with frozen requirements.