### PR TITLE
ENH: Sort color selection by hue

### DIFF
--- a/echofilter/inference.py
+++ b/echofilter/inference.py
@@ -1521,7 +1521,7 @@ def import_lines_regions_to_ev(
         print(f"Importing {len(files)} lines/regions into EV file {ev_fname}")
 
     # Assemble the color palette
-    colors = get_color_palette()
+    colors = get_color_palette(sort_colors=False)
 
     dtstr = datetime.datetime.now().isoformat(timespec="seconds")
 
@@ -1904,7 +1904,7 @@ def import_lines_regions_to_ev(
         ev_file.Save()
 
 
-def get_color_palette(include_xkcd=True):
+def get_color_palette(include_xkcd=True, sort_colors=True):
     """
     Provide a mapping of named colors from matplotlib.
 
@@ -1917,6 +1917,9 @@ def get_color_palette(include_xkcd=True):
         See https://xkcd.com/color/rgb/ and
         https://blog.xkcd.com/2010/05/03/color-survey-results/
         for the XKCD colors.
+    sort_colors : bool, default=True
+        Whether to sort the colors by hue. Otherwise the colors are grouped
+        together by source, and maintain their default ordering (alphabetized).
 
     Returns
     -------
@@ -1927,6 +1930,18 @@ def get_color_palette(include_xkcd=True):
     colors = dict(mcolors.BASE_COLORS, **mcolors.CSS4_COLORS)
     if include_xkcd:
         colors.update(**mcolors.XKCD_COLORS)
+
+    if not sort_colors:
+        return colors
+
+    # Sort colors by hue, saturation, value and name
+    by_hsv = sorted(
+        (tuple(mcolors.rgb_to_hsv(mcolors.to_rgb(color))), name)
+        for name, color in colors.items()
+    )
+    names = [name for hsv, name in by_hsv]
+    colors = {name: colors[name] for name in names}
+
     return colors
 
 

--- a/echofilter/inference.py
+++ b/echofilter/inference.py
@@ -1948,6 +1948,11 @@ def hexcolor2rgb8(color):
     """
     if isinstance(color, str) and color[0] == "#":
         color = mcolors.to_rgba(color)[:3]
+    if (
+        isinstance(color, tuple)
+        and any(isinstance(c, float) for c in color)
+        or all(c <= 1 for c in color)
+    ):
         color = tuple(max(0, min(255, int(np.round(c * 255)))) for c in color)
     return color
 

--- a/echofilter/tests/test_inference.py
+++ b/echofilter/tests/test_inference.py
@@ -393,6 +393,14 @@ class test_cli(BaseTestCase):
         with pytest.raises(SystemExit):
             inference_cli.cli(["--list-colors"])
 
+    def test_show_colors_alpha(self):
+        with pytest.raises(SystemExit):
+            inference_cli.cli(["--list-colors=alphabetic"])
+
+    def test_show_colors_full(self):
+        with pytest.raises(SystemExit):
+            inference_cli.cli(["--list-colors=full"])
+
     def test_dryrun(self):
         inference_cli.cli([self.resource_directory, "--dry-run"])
 

--- a/echofilter/tests/test_inference.py
+++ b/echofilter/tests/test_inference.py
@@ -90,7 +90,7 @@ class test_hexcolor2rgb8(BaseTestCase):
     def test_hexcolor2rgb8_pass(self):
         input = (0.5, 0.5, 0.5)
         out = inference.hexcolor2rgb8(input)
-        self.assertEqual(out, input)
+        self.assertEqual(out, (128, 128, 128))
 
     def test_hexcolor2rgb8_white(self):
         input = "#ffffff"

--- a/echofilter/ui/inference_cli.py
+++ b/echofilter/ui/inference_cli.py
@@ -45,9 +45,12 @@ class ListColors(argparse.Action):
 
         if values is None:
             include_xkcd = False
+            sort_colors = True
         else:
-            include_xkcd = values.lower() != "css4"
-        colors = get_color_palette(include_xkcd)
+            sort_colors = "alphabetic" not in values
+            include_xkcd = "full" in values or "xkcd" in values
+
+        colors = get_color_palette(include_xkcd, sort_colors=sort_colors)
         for key, value in colors.items():
             if isinstance(value, str):
                 hex = value
@@ -111,7 +114,7 @@ def get_parser():
         dest="list_colors",
         nargs="?",
         type=str,
-        choices=["css4", "full", "xkcd"],
+        choices=["alphabetic", "full", "full-alphabetic", "xkcd", "xkcd-alphabetic"],
         action=ListColors,
         help="""d|
             Show the available line color names and exit.
@@ -120,8 +123,10 @@ def get_parser():
             The XKCD color palette is also available, but is not
             shown in the output by default due to its size.
             To show the just main palette, run as ``--list-colors``
-            without argument, or ``--list-colors css4``. To show the
-            full palette, run as ``--list-colors full``.
+            without argument, or ``--list-colors alphabetic`` to view it in
+            alphabetic order. The default ordering is by hue.
+            To show the full palette, run as ``--list-colors full`` or
+            ``--list-colors full-alphabetic``.
         """,
     )
 

--- a/echofilter/ui/inference_cli.py
+++ b/echofilter/ui/inference_cli.py
@@ -116,7 +116,7 @@ def get_parser():
         help="""d|
             Show the available line color names and exit.
             The available color palette can be viewed at
-            https://matplotlib.org/gallery/color/named_colors.html.
+            https://matplotlib.org/stable/gallery/color/named_colors.html#css-colors.
             The XKCD color palette is also available, but is not
             shown in the output by default due to its size.
             To show the just main palette, run as ``--list-colors``

--- a/echofilter/ui/inference_cli.py
+++ b/echofilter/ui/inference_cli.py
@@ -39,6 +39,8 @@ DEFAULT_VARNAME = "Fileset1: Sv pings T1"
 
 class ListColors(argparse.Action):
     def __call__(self, parser, namespace, values, option_string):
+        import matplotlib.colors as mcolors
+
         from ..inference import get_color_palette, hexcolor2rgb8
 
         if values is None:
@@ -47,12 +49,14 @@ class ListColors(argparse.Action):
             include_xkcd = values.lower() != "css4"
         colors = get_color_palette(include_xkcd)
         for key, value in colors.items():
-            extra = hexcolor2rgb8(value)
-            if extra == value:
-                extra = ""
+            if isinstance(value, str):
+                hex = value
+                rgb8 = hexcolor2rgb8(hex)
             else:
-                extra = "  (" + ", ".join(["{:3d}".format(x) for x in extra]) + ")"
-            print("{:>31s}: {}{}".format(key, value, extra))
+                rgb8 = hexcolor2rgb8(value)
+                hex = mcolors.to_hex(value)
+            extra = "  (" + ", ".join(["{:3d}".format(x) for x in rgb8]) + ")"
+            print("{:>31s}: {}{}".format(key, hex, extra))
         parser.exit()  # exits the program with no more arg parsing and checking
 
 


### PR DESCRIPTION
- Convert colours in a 0--1 float format e.g. `(0.5, 0.5, 0.5)` into rg8, since I am not sure if the former is handled correctly by Echoview but the latter is. (Might be a bug, can't test it to find out.)
- Improve --list-colors output to show both hex and rgb8 values for all colours (before, single character colours didn't have hex values).
- Sort the output of --list-colors by hue, saturation, value instead of alphabetically by name, recycling code from https://matplotlib.org/stable/gallery/color/named_colors.html
- Change the --list-colors flag options, dropping  `"css4"` (which didn't do anything different from not including an option), and add `"full-alphabetic"` and `"xkcd-alphabetic"` options which sort the colours alphabetically (previously the default option).