### PR TITLE
DEV+DOC: Change references to source dir in conf.py to be absolute paths

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,9 +17,8 @@ import os
 import sys
 from inspect import getsourcefile
 
-REPO_DIR = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.abspath(getsourcefile(lambda: 0))))
-)
+DOCS_SOURCE_DIR = os.path.dirname(os.path.abspath(getsourcefile(lambda: 0)))
+REPO_DIR = os.path.dirname(os.path.dirname(DOCS_SOURCE_DIR))
 
 sys.path.insert(0, REPO_DIR)
 
@@ -57,7 +56,7 @@ def run_apidoc(_):
         # "--separate",  # Put each module file in its own page
         "--module-first",  # Put module documentation before submodule
         "-o",
-        "source/packages",  # Output path
+        os.path.join(DOCS_SOURCE_DIR, "packages"),  # Output path
         os.path.join(PACKAGE_DIR),
     ] + ignore_paths
 
@@ -75,7 +74,7 @@ def run_apidoc(_):
 
 
 def retitle_modules(_):
-    pth = "source/packages/modules.rst"
+    pth = os.path.join(DOCS_SOURCE_DIR, "packages", "modules.rst")
     lines = open(pth).read().splitlines()
     # Overwrite the junk in the first two lines with a better title
     lines[0] = "API Reference"


### PR DESCRIPTION
This fixes the problem seen on readthedocs, which was putting the API documentation in a source subdirectory next to the conf.py file.