### PR TITLE
API: Update checkpoint names

### DIFF
--- a/docs/source/usage/models.rst
+++ b/docs/source/usage/models.rst
@@ -9,58 +9,6 @@ command::
 All current checkpoints were trained on data acquired by
 `FORCE <http://fundyforce.ca>`__.
 
-Training Datasets
-~~~~~~~~~~~~~~~~~
-
-Stationary
-^^^^^^^^^^
-
-:data collection:
-    bottom-mounted :term:`stationary`, autonomous
-
-:orientation:
-    uplooking
-
-:echosounder:
-    120 kHz Simrad WBAT
-
-:locations:
-
-    - FORCE tidal power demonstration site, Minas Passage
-
-        - 45°21'47.34"N  64°25'38.94"W
-        - December 2017 through November 2018
-
-    - SMEC, Grand Passage
-
-        - 44°15'49.80"N  66°20'12.60"W
-        - December 2019 through January 2020
-
-:organization:
-    FORCE
-
-Mobile
-^^^^^^
-
-:data collection:
-    vessel-based 24-hour transect surveys
-
-:orientation:
-    downlooking
-
-:echosounder:
-    120 kHz Simrad EK80
-
-:locations:
-
-    -  FORCE tidal power demonstration site, Minas Passage
-
-        - 45°21'57.58"N  64°25'50.97"W
-        - May 2016 through October 2018
-
-:organization:
-    FORCE
-
 .. _Model checkpoints:
 
 Model checkpoints
@@ -151,6 +99,59 @@ echofilter-v0.5_downfacing_300ep
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 -   Trained on :term:`downfacing` :term:`mobile` data only.
+
+
+Training Datasets
+~~~~~~~~~~~~~~~~~
+
+Stationary
+^^^^^^^^^^
+
+:data collection:
+    bottom-mounted :term:`stationary`, autonomous
+
+:orientation:
+    uplooking
+
+:echosounder:
+    120 kHz Simrad WBAT
+
+:locations:
+
+    - FORCE tidal power demonstration site, Minas Passage
+
+        - 45°21'47.34"N  64°25'38.94"W
+        - December 2017 through November 2018
+
+    - SMEC, Grand Passage
+
+        - 44°15'49.80"N  66°20'12.60"W
+        - December 2019 through January 2020
+
+:organization:
+    FORCE
+
+Mobile
+^^^^^^
+
+:data collection:
+    vessel-based 24-hour transect surveys
+
+:orientation:
+    downlooking
+
+:echosounder:
+    120 kHz Simrad EK80
+
+:locations:
+
+    -  FORCE tidal power demonstration site, Minas Passage
+
+        - 45°21'57.58"N  64°25'50.97"W
+        - May 2016 through October 2018
+
+:organization:
+    FORCE
 
 .. raw:: latex
 

--- a/docs/source/usage/models.rst
+++ b/docs/source/usage/models.rst
@@ -74,7 +74,18 @@ throughout the network. The depth dimension of the input is halved
 (doubled) after each block, whilst the time dimension is halved
 (doubled) every other block.
 
-Details for notable model checkpoints are provided below.
+For details about how the Echofilter models were trained, and our findings about
+their empirical performance, please consult our companion paper:
+
+    SC Lowe, LP McGarry, J Douglas, J Newport, S Oore, C Whidden, DJ Hasselman (2022). Echofilter: A Deep Learning Segmention Model Improves the Automation, Standardization, and Timeliness for Post-Processing Echosounder Data in Tidal Energy Streams. *Front. Mar. Sci.*, **9**, 1–21.
+    doi: |nbsp| `10.3389/fmars.2022.867857 <doi_>`_.
+
+.. |nbsp| unicode:: 0xA0
+   :trim:
+.. _doi: https://www.doi.org/10.3389/fmars.2022.867857
+
+An overview for of notable model checkpoints available in echofilter are
+provided below.
 
 echofilter-v1_bifacing_700ep
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/usage/models.rst
+++ b/docs/source/usage/models.rst
@@ -83,7 +83,7 @@ Details for notable model checkpoints are provided below.
 
    -  Overall IoU performance of
       **99.15%** on :term:`downfacing` :term:`mobile` and
-      94.91% on :term:`upfacing` :term:`stationary`
+      93.0%--94.9% on :term:`upfacing` :term:`stationary`
       :term:`test<Test set>` data.
 
    -  Default model checkpoint.
@@ -95,7 +95,7 @@ Details for notable model checkpoints are provided below.
 
    -  Overall IoU performance of
       99.02% on :term:`downfacing` :term:`mobile` and
-      94.97% on :term:`upfacing` :term:`stationary`
+      93.2%--95.0% on :term:`upfacing` :term:`stationary`
       :term:`test<Test set>` data.
 
 :echofilter-v1_bifacing_100ep:
@@ -105,7 +105,7 @@ Details for notable model checkpoints are provided below.
 
    -  Overall IoU performance of
       98.93% on :term:`downfacing` :term:`mobile` and
-      94.93% on :term:`upfacing` :term:`stationary`
+      **93.5%**--94.9% on :term:`upfacing` :term:`stationary`
       :term:`test<Test set>` data.
 
    -  :term:`Sample<Sample (model input)>` outputs on :term:`upfacing`
@@ -117,7 +117,7 @@ Details for notable model checkpoints are provided below.
    -  Trained on :term:`upfacing` :term:`stationary` data only.
 
    -  Overall IoU performance of
-      **95.08%** on :term:`upfacing` :term:`stationary`
+      92.1%--**95.1%** on :term:`upfacing` :term:`stationary`
       :term:`test<Test set>` data.
 
 :echofilter-v1_upfacing_200ep:
@@ -125,7 +125,7 @@ Details for notable model checkpoints are provided below.
    -  Trained on :term:`upfacing` :term:`stationary` data only.
 
    -  Overall IoU performance of
-      95.05% on :term:`upfacing` :term:`stationary`
+      93.3%--95.1% on :term:`upfacing` :term:`stationary`
       :term:`test<Test set>` data.
 
    -  :term:`Sample<Sample (model input)>` outputs thoroughly were thoroughly

--- a/docs/source/usage/models.rst
+++ b/docs/source/usage/models.rst
@@ -81,9 +81,10 @@ Details for notable model checkpoints are provided below.
    -  Trained on both :term:`upfacing` :term:`stationary` and
       :term:`downfacing` :term:`mobile` data.
 
-   -  Jaccard Index of **96.84%** on :term:`downfacing` :term:`mobile` and
-      **94.51%** on :term:`upfacing` :term:`stationary`
-      :term:`validation<Validation set>` data.
+   -  Overall IoU performance of
+      **99.15%** on :term:`downfacing` :term:`mobile` and
+      94.91% on :term:`upfacing` :term:`stationary`
+      :term:`test<Test set>` data.
 
    -  Default model checkpoint.
 
@@ -92,18 +93,20 @@ Details for notable model checkpoints are provided below.
    -  Trained on both :term:`upfacing` :term:`stationary` and
       :term:`downfacing` :term:`mobile` data.
 
-   -  Jaccard Index of 96.8% on :term:`downfacing` :term:`mobile` and
-      94.4% on :term:`upfacing` :term:`stationary`
-      :term:`validation<Validation set>` data.
+   -  Overall IoU performance of
+      99.02% on :term:`downfacing` :term:`mobile` and
+      94.97% on :term:`upfacing` :term:`stationary`
+      :term:`test<Test set>` data.
 
 :echofilter-v1_bifacing_100ep:
 
    -  Trained on both :term:`upfacing` :term:`stationary` and
       :term:`downfacing` :term:`mobile` data.
 
-   -  Jaccard Index of 96.62% on :term:`downfacing` :term:`mobile` and
-      94.29% on :term:`upfacing` :term:`stationary`
-      :term:`validation<Validation set>` data.
+   -  Overall IoU performance of
+      98.93% on :term:`downfacing` :term:`mobile` and
+      94.93% on :term:`upfacing` :term:`stationary`
+      :term:`test<Test set>` data.
 
    -  :term:`Sample<Sample (model input)>` outputs on :term:`upfacing`
       :term:`stationary` data were thoroughly verified via manual inspection
@@ -113,15 +116,17 @@ Details for notable model checkpoints are provided below.
 
    -  Trained on :term:`upfacing` :term:`stationary` data only.
 
-   -  Jaccard Index of 94.4% on :term:`upfacing` :term:`stationary`
-      :term:`validation<Validation set>` data.
+   -  Overall IoU performance of
+      **95.08%** on :term:`upfacing` :term:`stationary`
+      :term:`test<Test set>` data.
 
 :echofilter-v1_upfacing_200ep:
 
    -  Trained on :term:`upfacing` :term:`stationary` data only.
 
-   -  Jaccard Index of 94.41% on :term:`upfacing` :term:`stationary`
-      :term:`validation<Validation set>` data.
+   -  Overall IoU performance of
+      95.05% on :term:`upfacing` :term:`stationary`
+      :term:`test<Test set>` data.
 
    -  :term:`Sample<Sample (model input)>` outputs thoroughly were thoroughly
       verified via manual inspection by trained analysts.

--- a/docs/source/usage/models.rst
+++ b/docs/source/usage/models.rst
@@ -76,64 +76,70 @@ throughout the network. The depth dimension of the input is halved
 
 Details for notable model checkpoints are provided below.
 
-:echofilter-v1_bifacing_700ep:
+echofilter-v1_bifacing_700ep
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-   -  Trained on both :term:`upfacing` :term:`stationary` and
-      :term:`downfacing` :term:`mobile` data.
+-   Trained on both :term:`upfacing` :term:`stationary` and
+    :term:`downfacing` :term:`mobile` data.
 
-   -  Overall IoU performance of
-      **99.15%** on :term:`downfacing` :term:`mobile` and
-      93.0%--94.9% on :term:`upfacing` :term:`stationary`
-      :term:`test<Test set>` data.
+-   Overall IoU performance of
+    **99.15%** on :term:`downfacing` :term:`mobile` and
+    93.0%--94.9% on :term:`upfacing` :term:`stationary`
+    :term:`test<Test set>` data.
 
-   -  Default model checkpoint.
+-   Default model checkpoint.
 
-:echofilter-v1_bifacing_300ep:
+echofilter-v1_bifacing_300ep
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-   -  Trained on both :term:`upfacing` :term:`stationary` and
-      :term:`downfacing` :term:`mobile` data.
+-   Trained on both :term:`upfacing` :term:`stationary` and
+    :term:`downfacing` :term:`mobile` data.
 
-   -  Overall IoU performance of
-      99.02% on :term:`downfacing` :term:`mobile` and
-      93.2%--95.0% on :term:`upfacing` :term:`stationary`
-      :term:`test<Test set>` data.
+-   Overall IoU performance of
+    99.02% on :term:`downfacing` :term:`mobile` and
+    93.2%--95.0% on :term:`upfacing` :term:`stationary`
+    :term:`test<Test set>` data.
 
-:echofilter-v1_bifacing_100ep:
+echofilter-v1_bifacing_100ep
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-   -  Trained on both :term:`upfacing` :term:`stationary` and
-      :term:`downfacing` :term:`mobile` data.
+-   Trained on both :term:`upfacing` :term:`stationary` and
+    :term:`downfacing` :term:`mobile` data.
 
-   -  Overall IoU performance of
-      98.93% on :term:`downfacing` :term:`mobile` and
-      **93.5%**--94.9% on :term:`upfacing` :term:`stationary`
-      :term:`test<Test set>` data.
+-   Overall IoU performance of
+    98.93% on :term:`downfacing` :term:`mobile` and
+    **93.5%**--94.9% on :term:`upfacing` :term:`stationary`
+    :term:`test<Test set>` data.
 
-   -  :term:`Sample<Sample (model input)>` outputs on :term:`upfacing`
-      :term:`stationary` data were thoroughly verified via manual inspection
-      by trained analysts.
+-   :term:`Sample<Sample (model input)>` outputs on :term:`upfacing`
+    :term:`stationary` data were thoroughly verified via manual inspection
+    by trained analysts.
 
-:echofilter-v1_upfacing_600ep:
+echofilter-v1_upfacing_600ep
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-   -  Trained on :term:`upfacing` :term:`stationary` data only.
+-   Trained on :term:`upfacing` :term:`stationary` data only.
 
-   -  Overall IoU performance of
-      92.1%--**95.1%** on :term:`upfacing` :term:`stationary`
-      :term:`test<Test set>` data.
+-   Overall IoU performance of
+    92.1%--**95.1%** on :term:`upfacing` :term:`stationary`
+    :term:`test<Test set>` data.
 
-:echofilter-v1_upfacing_200ep:
+echofilter-v1_upfacing_200ep
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-   -  Trained on :term:`upfacing` :term:`stationary` data only.
+-   Trained on :term:`upfacing` :term:`stationary` data only.
 
-   -  Overall IoU performance of
-      93.3%--95.1% on :term:`upfacing` :term:`stationary`
-      :term:`test<Test set>` data.
+-   Overall IoU performance of
+    93.3%--95.1% on :term:`upfacing` :term:`stationary`
+    :term:`test<Test set>` data.
 
-   -  :term:`Sample<Sample (model input)>` outputs thoroughly were thoroughly
-      verified via manual inspection by trained analysts.
+-   :term:`Sample<Sample (model input)>` outputs thoroughly were thoroughly
+    verified via manual inspection by trained analysts.
 
-:echofilter-v0.5_downfacing_300ep:
+echofilter-v0.5_downfacing_300ep
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-   -  Trained on :term:`downfacing` :term:`mobile` data only.
+-   Trained on :term:`downfacing` :term:`mobile` data only.
 
 .. raw:: latex
 

--- a/docs/source/usage/models.rst
+++ b/docs/source/usage/models.rst
@@ -76,7 +76,7 @@ throughout the network. The depth dimension of the input is halved
 
 Details for notable model checkpoints are provided below.
 
-:conditional_mobile-stationary2_effunet6x2-1_lc32_v2.2:
+:echofilter-v1_bifacing_700ep:
 
    -  Trained on both :term:`upfacing` :term:`stationary` and
       :term:`downfacing` :term:`mobile` data.
@@ -87,7 +87,7 @@ Details for notable model checkpoints are provided below.
 
    -  Default model checkpoint.
 
-:conditional_mobile-stationary2_effunet6x2-1_lc32_v2.1:
+:echofilter-v1_bifacing_300ep:
 
    -  Trained on both :term:`upfacing` :term:`stationary` and
       :term:`downfacing` :term:`mobile` data.
@@ -96,7 +96,7 @@ Details for notable model checkpoints are provided below.
       94.4% on :term:`upfacing` :term:`stationary`
       :term:`validation<Validation set>` data.
 
-:conditional_mobile-stationary2_effunet6x2-1_lc32_v2.0:
+:echofilter-v1_bifacing_100ep:
 
    -  Trained on both :term:`upfacing` :term:`stationary` and
       :term:`downfacing` :term:`mobile` data.
@@ -109,14 +109,14 @@ Details for notable model checkpoints are provided below.
       :term:`stationary` data were thoroughly verified via manual inspection
       by trained analysts.
 
-:stationary2_effunet6x2-1_lc32_v2.1:
+:echofilter-v1_upfacing_600ep:
 
    -  Trained on :term:`upfacing` :term:`stationary` data only.
 
    -  Jaccard Index of 94.4% on :term:`upfacing` :term:`stationary`
       :term:`validation<Validation set>` data.
 
-:stationary2_effunet6x2-1_lc32_v2.0:
+:echofilter-v1_upfacing_200ep:
 
    -  Trained on :term:`upfacing` :term:`stationary` data only.
 
@@ -126,7 +126,7 @@ Details for notable model checkpoints are provided below.
    -  :term:`Sample<Sample (model input)>` outputs thoroughly were thoroughly
       verified via manual inspection by trained analysts.
 
-:mobile_effunet6x2-1_lc32_v1.0:
+:echofilter-v0.5_downfacing_300ep:
 
    -  Trained on :term:`downfacing` :term:`mobile` data only.
 

--- a/docs/source/usage/models.rst
+++ b/docs/source/usage/models.rst
@@ -104,6 +104,12 @@ echofilter-v0.5_downfacing_300ep
 Training Datasets
 ~~~~~~~~~~~~~~~~~
 
+The machine learning model was trained on upfacing stationary and downfacing
+mobile data provided by Fundy Ocean Research Centre for Energy (FORCE).
+The training and evaluation data is
+`available for download <https://data.fundyforce.ca/forceCloud/index.php/s/BzC87LpbGtnFsjT>`__.
+Queries regarding dataset access should be directed to FORCE, info@fundyforce.ca.
+
 Stationary
 ^^^^^^^^^^
 

--- a/echofilter/checkpoints.yaml
+++ b/echofilter/checkpoints.yaml
@@ -7,6 +7,10 @@ checkpoints:
         aliases: ["conditional_mobile-stationary2_effunet6x2-1_lc32_v2.2", "echofilter-v1_bifacing"],
         gdrive: "1mlzjIu5hHQI2UbMDYe7WB9jjpzAOwlMp",
     }
+    echofilter-v1_bifacing_612ep: {
+        aliases: ["conditional_mobile-stationary2_effunet6x2-1_lc32_v2.2b"],
+        gdrive: "1urPv3Vah7UX_dVCouo4znKAV2RtxqkK4",
+    }
 
     # 2020-07-08_08.31.04_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.006_mesa_mom.92-.98_w.1-.5_ep200_v2.1_warm-restart-from-2020-06-30_21.24.07
     echofilter-v1_bifacing_300ep: {

--- a/echofilter/checkpoints.yaml
+++ b/echofilter/checkpoints.yaml
@@ -1,60 +1,60 @@
 title: "echofilter checkpoints"
-date: 2020-07-27T15:00:00Z
+date: 2022-11-13T05:00:00Z
 
 checkpoints:
-  # 2020-07-15_13.51.13_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.003_mesa_mom.92-.98_w.1-.5_ep400_v2.2_warm-restart-from-2020-07-08_08.31.04
-  conditional_mobile-stationary2_effunet6x2-1_lc32_v2.2: {
-    gdrive: "1mlzjIu5hHQI2UbMDYe7WB9jjpzAOwlMp",
-  }
+    # 2020-07-15_13.51.13_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.003_mesa_mom.92-.98_w.1-.5_ep400_v2.2_warm-restart-from-2020-07-08_08.31.04
+    conditional_mobile-stationary2_effunet6x2-1_lc32_v2.2: {
+        gdrive: "1mlzjIu5hHQI2UbMDYe7WB9jjpzAOwlMp",
+    }
 
-  # 2020-07-08_08.31.04_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.006_mesa_mom.92-.98_w.1-.5_ep200_v2.1_warm-restart-from-2020-06-30_21.24.07
-  conditional_mobile-stationary2_effunet6x2-1_lc32_v2.1b: {
-    gdrive: "1dWEvbnUWjGa-B93L-dlDyqI4N411EK0G",
-  }
-  conditional_mobile-stationary2_effunet6x2-1_lc32_v2.1: {
-    gdrive: "1lC7tnD2nRgl7oHtkWzkD-W8teDTDa0ky",
-  }
+    # 2020-07-08_08.31.04_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.006_mesa_mom.92-.98_w.1-.5_ep200_v2.1_warm-restart-from-2020-06-30_21.24.07
+    conditional_mobile-stationary2_effunet6x2-1_lc32_v2.1b: {
+        gdrive: "1dWEvbnUWjGa-B93L-dlDyqI4N411EK0G",
+    }
+    conditional_mobile-stationary2_effunet6x2-1_lc32_v2.1: {
+        gdrive: "1lC7tnD2nRgl7oHtkWzkD-W8teDTDa0ky",
+    }
 
-  # 2020-06-30_21.24.07_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.012_mesa_mom.92-.98_w.1-.5_ep100
-  conditional_mobile-stationary2_effunet6x2-1_lc32_v2.0b: {
-    gdrive: "1NBGoFG-UIUWG5k7uePkXfrJ9gfVRvsv4",
-  }
-  conditional_mobile-stationary2_effunet6x2-1_lc32_v2.0: {
-    gdrive: "1jBo3vCsUz8UVfJJnc5XEqNDLFrUpers7",
-  }
+    # 2020-06-30_21.24.07_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.012_mesa_mom.92-.98_w.1-.5_ep100
+    conditional_mobile-stationary2_effunet6x2-1_lc32_v2.0b: {
+        gdrive: "1NBGoFG-UIUWG5k7uePkXfrJ9gfVRvsv4",
+    }
+    conditional_mobile-stationary2_effunet6x2-1_lc32_v2.0: {
+        gdrive: "1jBo3vCsUz8UVfJJnc5XEqNDLFrUpers7",
+    }
 
-  # 2020-07-02_07.41.22_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.012_mesa_mom.92-.98_w.1-.5_ep50_warm-restart-from-2020-06-15-05.39.07
-  conditional_mobile-stationary2_effunet6x2-1_lc32_v1.1: {
-    gdrive: "1mIN_PBMAgFK1KmL3tSkXIkkT9pNEy8O3",
-  }
+    # 2020-07-02_07.41.22_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.012_mesa_mom.92-.98_w.1-.5_ep50_warm-restart-from-2020-06-15-05.39.07
+    conditional_mobile-stationary2_effunet6x2-1_lc32_v1.1: {
+        gdrive: "1mIN_PBMAgFK1KmL3tSkXIkkT9pNEy8O3",
+    }
 
-  # 2020-06-15_05.39.07_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.016_mesa_mom.92-.98_w.1-.5_ep100_elastic_resume5
-  conditional_mobile-stationary2_effunet6x2-1_lc32_v1.0: {
-    gdrive: "1vEshqJbj906tCEA4KybUmlBXN9YEG_Fu",
-  }
+    # 2020-06-15_05.39.07_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.016_mesa_mom.92-.98_w.1-.5_ep100_elastic_resume5
+    conditional_mobile-stationary2_effunet6x2-1_lc32_v1.0: {
+        gdrive: "1vEshqJbj906tCEA4KybUmlBXN9YEG_Fu",
+    }
 
-  # 2020-07-09_09.39.12_effunet6x.2-1_lc32-se2_bs12-lr0.006_mesa_mom.92-.98_w.1-.5_ep400_warm-restart-2020-07-05_21.01.31
-  stationary2_effunet6x2-1_lc32_v2.1b: {
-    gdrive: "127DUtR3lsPPAyajSGsPSZ0odJBEk7qO2",
-  }
-  stationary2_effunet6x2-1_lc32_v2.1: {
-    gdrive: "1_FIzYT2X0WX-VDmU-3KprznCZhLSreJ_",
-  }
+    # 2020-07-09_09.39.12_effunet6x.2-1_lc32-se2_bs12-lr0.006_mesa_mom.92-.98_w.1-.5_ep400_warm-restart-2020-07-05_21.01.31
+    stationary2_effunet6x2-1_lc32_v2.1b: {
+        gdrive: "127DUtR3lsPPAyajSGsPSZ0odJBEk7qO2",
+    }
+    stationary2_effunet6x2-1_lc32_v2.1: {
+        gdrive: "1_FIzYT2X0WX-VDmU-3KprznCZhLSreJ_",
+    }
 
-  # 2020-07-05_21.01.31_effunet6x.2-1_lc32-se2_bs12-lr0.012_mesa_mom.92-.98_w.1-.5_ep200
-  stationary2_effunet6x2-1_lc32_v2.0b: {
-    gdrive: "1ouMLMhxJBXgO98Oyq-9TEEBBBudtznzP",
-  }
-  stationary2_effunet6x2-1_lc32_v2.0: {
-    gdrive: "1ZjTMMOZd_MlBb3PQbHhltHPGrB9szSoT",
-  }
+    # 2020-07-05_21.01.31_effunet6x.2-1_lc32-se2_bs12-lr0.012_mesa_mom.92-.98_w.1-.5_ep200
+    stationary2_effunet6x2-1_lc32_v2.0b: {
+        gdrive: "1ouMLMhxJBXgO98Oyq-9TEEBBBudtznzP",
+    }
+    stationary2_effunet6x2-1_lc32_v2.0: {
+        gdrive: "1ZjTMMOZd_MlBb3PQbHhltHPGrB9szSoT",
+    }
 
-  # 2020-06-14_14.24.21_effunet6x.2-1_lc32-se2_bs20-lr0.02_mesa_mom.92-.98_w.1-.5_ep150_elastic_epseed_resume2
-  stationary2_effunet6x2-1_lc32_v1.0: {
-    gdrive: "1qPg9lUbtLk_DOR86sPS-DAvOaAlnvAF_",
-  }
+    # 2020-06-14_14.24.21_effunet6x.2-1_lc32-se2_bs20-lr0.02_mesa_mom.92-.98_w.1-.5_ep150_elastic_epseed_resume2
+    stationary2_effunet6x2-1_lc32_v1.0: {
+        gdrive: "1qPg9lUbtLk_DOR86sPS-DAvOaAlnvAF_",
+    }
 
-  # 2020-06-14_13.53.10_effunet6x.2-1_lc32-se2_bs30-lr0.02_mesa_mom.92-.98_w.1-.5_ep300_elastic_epseed_resume2
-  mobile_effunet6x2-1_lc32_v1.0: {
-    gdrive: "1yODjTcRsGc3v8cNZqFZjqbtGHHwoAohU",
-  }
+    # 2020-06-14_13.53.10_effunet6x.2-1_lc32-se2_bs30-lr0.02_mesa_mom.92-.98_w.1-.5_ep300_elastic_epseed_resume2
+    mobile_effunet6x2-1_lc32_v1.0: {
+        gdrive: "1yODjTcRsGc3v8cNZqFZjqbtGHHwoAohU",
+    }

--- a/echofilter/checkpoints.yaml
+++ b/echofilter/checkpoints.yaml
@@ -1,60 +1,73 @@
 title: "echofilter checkpoints"
-date: 2022-11-13T05:00:00Z
+date: 2022-11-17T05:00:00Z
 
 checkpoints:
     # 2020-07-15_13.51.13_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.003_mesa_mom.92-.98_w.1-.5_ep400_v2.2_warm-restart-from-2020-07-08_08.31.04
-    conditional_mobile-stationary2_effunet6x2-1_lc32_v2.2: {
+    echofilter-v1_bifacing_700ep: {
+        aliases: ["conditional_mobile-stationary2_effunet6x2-1_lc32_v2.2", "echofilter-v1_bifacing"],
         gdrive: "1mlzjIu5hHQI2UbMDYe7WB9jjpzAOwlMp",
     }
 
     # 2020-07-08_08.31.04_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.006_mesa_mom.92-.98_w.1-.5_ep200_v2.1_warm-restart-from-2020-06-30_21.24.07
-    conditional_mobile-stationary2_effunet6x2-1_lc32_v2.1b: {
-        gdrive: "1dWEvbnUWjGa-B93L-dlDyqI4N411EK0G",
-    }
-    conditional_mobile-stationary2_effunet6x2-1_lc32_v2.1: {
+    echofilter-v1_bifacing_300ep: {
+        aliases: ["conditional_mobile-stationary2_effunet6x2-1_lc32_v2.1"],
         gdrive: "1lC7tnD2nRgl7oHtkWzkD-W8teDTDa0ky",
+    }
+    echofilter-v1_bifacing_283ep: {
+        aliases: ["conditional_mobile-stationary2_effunet6x2-1_lc32_v2.1b"],
+        gdrive: "1dWEvbnUWjGa-B93L-dlDyqI4N411EK0G",
     }
 
     # 2020-06-30_21.24.07_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.012_mesa_mom.92-.98_w.1-.5_ep100
-    conditional_mobile-stationary2_effunet6x2-1_lc32_v2.0b: {
-        gdrive: "1NBGoFG-UIUWG5k7uePkXfrJ9gfVRvsv4",
-    }
-    conditional_mobile-stationary2_effunet6x2-1_lc32_v2.0: {
+    echofilter-v1_bifacing_100ep: {
+        aliases: ["conditional_mobile-stationary2_effunet6x2-1_lc32_v2.0"],
         gdrive: "1jBo3vCsUz8UVfJJnc5XEqNDLFrUpers7",
+    }
+    echofilter-v1_bifacing_97ep: {
+        aliases: ["conditional_mobile-stationary2_effunet6x2-1_lc32_v2.0b"],
+        gdrive: "1NBGoFG-UIUWG5k7uePkXfrJ9gfVRvsv4",
     }
 
     # 2020-07-02_07.41.22_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.012_mesa_mom.92-.98_w.1-.5_ep50_warm-restart-from-2020-06-15-05.39.07
-    conditional_mobile-stationary2_effunet6x2-1_lc32_v1.1: {
+    echofilter-v0.5_bifacing_150ep: {
+        aliases: ["conditional_mobile-stationary2_effunet6x2-1_lc32_v1.1", "echofilter-v0.5_bifacing"],
         gdrive: "1mIN_PBMAgFK1KmL3tSkXIkkT9pNEy8O3",
     }
 
     # 2020-06-15_05.39.07_conditional_effunet6x.2-1_lc32-se2_bs12-lr0.016_mesa_mom.92-.98_w.1-.5_ep100_elastic_resume5
-    conditional_mobile-stationary2_effunet6x2-1_lc32_v1.0: {
+    echofilter-v0.5_bifacing_100ep: {
+        aliases: ["conditional_mobile-stationary2_effunet6x2-1_lc32_v1.0"],
         gdrive: "1vEshqJbj906tCEA4KybUmlBXN9YEG_Fu",
     }
 
     # 2020-07-09_09.39.12_effunet6x.2-1_lc32-se2_bs12-lr0.006_mesa_mom.92-.98_w.1-.5_ep400_warm-restart-2020-07-05_21.01.31
-    stationary2_effunet6x2-1_lc32_v2.1b: {
-        gdrive: "127DUtR3lsPPAyajSGsPSZ0odJBEk7qO2",
-    }
-    stationary2_effunet6x2-1_lc32_v2.1: {
+    echofilter-v1_upfacing_600ep: {
+        aliases: ["stationary2_effunet6x2-1_lc32_v2.1", "echofilter-v1_upfacing"],
         gdrive: "1_FIzYT2X0WX-VDmU-3KprznCZhLSreJ_",
+    }
+    echofilter-v1_upfacing_599ep: {
+        aliases: ["stationary2_effunet6x2-1_lc32_v2.1b"],
+        gdrive: "127DUtR3lsPPAyajSGsPSZ0odJBEk7qO2",
     }
 
     # 2020-07-05_21.01.31_effunet6x.2-1_lc32-se2_bs12-lr0.012_mesa_mom.92-.98_w.1-.5_ep200
-    stationary2_effunet6x2-1_lc32_v2.0b: {
-        gdrive: "1ouMLMhxJBXgO98Oyq-9TEEBBBudtznzP",
-    }
-    stationary2_effunet6x2-1_lc32_v2.0: {
+    echofilter-v1_upfacing_200ep: {
+        aliases: ["stationary2_effunet6x2-1_lc32_v2.0"],
         gdrive: "1ZjTMMOZd_MlBb3PQbHhltHPGrB9szSoT",
+    }
+    echofilter-v1_upfacing_190ep: {
+        aliases: ["stationary2_effunet6x2-1_lc32_v2.0b"],
+        gdrive: "1ouMLMhxJBXgO98Oyq-9TEEBBBudtznzP",
     }
 
     # 2020-06-14_14.24.21_effunet6x.2-1_lc32-se2_bs20-lr0.02_mesa_mom.92-.98_w.1-.5_ep150_elastic_epseed_resume2
-    stationary2_effunet6x2-1_lc32_v1.0: {
+    echofilter-v0.5_upfacing_150ep: {
+        aliases: ["stationary2_effunet6x2-1_lc32_v1.0", "echofilter-v0.5_upfacing"],
         gdrive: "1qPg9lUbtLk_DOR86sPS-DAvOaAlnvAF_",
     }
 
     # 2020-06-14_13.53.10_effunet6x.2-1_lc32-se2_bs30-lr0.02_mesa_mom.92-.98_w.1-.5_ep300_elastic_epseed_resume2
-    mobile_effunet6x2-1_lc32_v1.0: {
+    echofilter-v0.5_downfacing_300ep: {
+        aliases: ["mobile_effunet6x2-1_lc32_v1.0", "echofilter-v0.5_downfacing"],
         gdrive: "1yODjTcRsGc3v8cNZqFZjqbtGHHwoAohU",
     }

--- a/echofilter/ui/checkpoints.py
+++ b/echofilter/ui/checkpoints.py
@@ -164,7 +164,22 @@ def download_checkpoint(checkpoint_name, cache_dir=None, verbose=1):
 
     os.makedirs(cache_dir, exist_ok=True)
 
-    sources = get_checkpoint_list()[checkpoint_name]
+    checkpoints_dict = get_checkpoint_list()
+    if checkpoint_name in checkpoints_dict:
+        sources = checkpoints_dict[checkpoint_name]
+    else:
+        for key, sources in checkpoints_dict.items():
+            if checkpoint_name in sources.get("aliases", []):
+                checkpoint_name = key
+                break
+        else:
+            raise ValueError(
+                f"No checkpoint named {checkpoint_name} found checkpoints.yaml"
+            )
+
+    if "aliases" in sources:
+        sources.pop("aliases")
+
     success = False
     for key, url_or_id in sources.items():
         if key == "gdrive":

--- a/echofilter/ui/checkpoints.py
+++ b/echofilter/ui/checkpoints.py
@@ -105,8 +105,10 @@ def cannonise_checkpoint_name(name):
 class ListCheckpoints(argparse.Action):
     def __call__(self, parser, namespace, values, option_string):
         print("Currently available model checkpoints:")
-        for checkpoint in get_checkpoint_list():
-            if checkpoint == get_default_checkpoint():
+        default_checkpoint = get_default_checkpoint()
+        checkpoints = get_checkpoint_list()
+        for checkpoint in checkpoints:
+            if checkpoint == default_checkpoint:
                 print("  * " + style.progress_fmt(checkpoint))
             else:
                 print("    " + checkpoint)


### PR DESCRIPTION
Change checkpoint names to be more user-friendly, corresponding to the models used in the paper.

The previous checkpoint names are still supported, as aliases to the new names.