### PR TITLE
API+DEP: Minimize instead of hiding Echoview by default

### DIFF
--- a/echofilter/ev2csv.py
+++ b/echofilter/ev2csv.py
@@ -25,6 +25,7 @@ import warnings
 
 from tqdm.auto import tqdm
 
+import echofilter
 import echofilter.path
 import echofilter.ui
 import echofilter.utils
@@ -602,6 +603,15 @@ def main(args=None):
     parser = get_parser()
     kwargs = vars(parser.parse_args(args))
     kwargs["verbose"] -= kwargs.pop("quiet", 0)
+
+    if kwargs["verbose"] >= 2:
+        import echofilter.ui.style
+
+        print(
+            echofilter.ui.style.aside_fmt(
+                f"Running ev2csv routine, version {echofilter.__version__}"
+            )
+        )
 
     if kwargs["hide_echoview"] is None:
         kwargs["hide_echoview"] = "never" if kwargs["minimize_echoview"] else "new"

--- a/echofilter/ev2csv.py
+++ b/echofilter/ev2csv.py
@@ -616,6 +616,13 @@ def main(args=None):
     if kwargs["hide_echoview"] is None:
         kwargs["hide_echoview"] = "never" if kwargs["minimize_echoview"] else "new"
 
+    if kwargs["verbose"] >= 3:
+        import pprint
+
+        print("\nFull list of keyword arguments:")
+        pprint.pprint(kwargs)
+        print("")
+
     run_ev2csv(**kwargs)
 
 

--- a/echofilter/ev2csv.py
+++ b/echofilter/ev2csv.py
@@ -520,7 +520,7 @@ def get_parser():
         help="""
             Hide any Echoview window spawned by this program. If it must use
             an Echoview instance which was already running, that window is not
-            hidden. This is the default behaviour.
+            hidden.
         """,
     )
     group_evwin_hiding.add_argument(
@@ -530,8 +530,7 @@ def get_parser():
         const="never",
         default=None,
         help="""
-            Don't hide an Echoview window created to run this code. (Disables
-            the default behaviour which is equivalent to ``--hide-echoview``.)
+            Don't hide or minimize an Echoview window created to run this code.
         """,
     )
     group_evwin_hiding.add_argument(
@@ -552,8 +551,7 @@ def get_parser():
         help="""
             Minimize any Echoview window used to runs this code while it runs.
             The window will be restored once the program is finished.
-            If this argument is supplied, ``--show-echoview`` is implied unless
-            ``--hide-echoview`` is also given.
+            This is the default behaviour.
         """,
     )
 
@@ -614,7 +612,10 @@ def main(args=None):
         )
 
     if kwargs["hide_echoview"] is None:
-        kwargs["hide_echoview"] = "never" if kwargs["minimize_echoview"] else "new"
+        kwargs["hide_echoview"] = "never"
+        kwargs["minimize_echoview"] = True
+    elif kwargs["minimize_echoview"] is None:
+        kwargs["minimize_echoview"] = False
 
     if kwargs["verbose"] >= 3:
         import pprint

--- a/echofilter/inference.py
+++ b/echofilter/inference.py
@@ -443,6 +443,16 @@ def run_inference(
         " outputs."
     )
 
+    if hide_echoview != "never":
+        if verbose >= 0:
+            s = (
+                "Warning: Hiding Echoview may result in unwanted side-effects."
+                "\nFor details, see https://github.com/DeepSenseCA/echofilter/issues/337"
+                "\nWarning: Hiding Echoview during inference is deprecated."
+            )
+            s = echofilter.ui.style.warning_fmt(s)
+            print(s)
+
     if verbose >= 1:
         print(
             progress_fmt(

--- a/echofilter/inference.py
+++ b/echofilter/inference.py
@@ -27,6 +27,7 @@ import sys
 import tempfile
 import textwrap
 import time
+import warnings
 
 import numpy as np
 import torch
@@ -420,6 +421,11 @@ def run_inference(
         If ``hide_echoview="always"``, the application is hidden even if it was
         already running. In the latter case, the window will be revealed again
         when this function is completed.
+
+        .. deprecated:: 1.2.1
+           Support for hiding echoview during inference will be dropped in a
+           future release.
+
     minimize_echoview : bool, default=True
         If ``True`` (default), the Echoview window being used will be minimized
         while this function is running.
@@ -444,6 +450,9 @@ def run_inference(
     )
 
     if hide_echoview != "never":
+        warnings.warn(
+            "Hiding Echoview during inference is deprecated.", DeprecationWarning
+        )
         if verbose >= 0:
             s = (
                 "Warning: Hiding Echoview may result in unwanted side-effects."

--- a/echofilter/inference.py
+++ b/echofilter/inference.py
@@ -119,8 +119,8 @@ def run_inference(
     force_unconditioned=False,
     logit_smoothing_sigma=0,
     device=None,
-    hide_echoview="new",
-    minimize_echoview=False,
+    hide_echoview="never",
+    minimize_echoview=True,
     verbose=2,
 ):
     """
@@ -413,16 +413,16 @@ def run_inference(
         Name of device on which the model will be run. By default, the first
         available CUDA GPU is used if any are found, and otherwise the CPU is
         used. Set to ``"cpu"`` to use the CPU even if a CUDA GPU is available.
-    hide_echoview : {"never", "new", "always"}, default="new"
+    hide_echoview : {"never", "new", "always"}, default="never"
         Whether to hide the Echoview window entirely while the code runs.
         If ``hide_echoview="new"``, the application is only hidden if it
         was created by this function, and not if it was already running.
         If ``hide_echoview="always"``, the application is hidden even if it was
         already running. In the latter case, the window will be revealed again
         when this function is completed.
-    minimize_echoview : bool, default=False
-        If ``True``, the Echoview window being used will be minimized while this
-        function is running.
+    minimize_echoview : bool, default=True
+        If ``True`` (default), the Echoview window being used will be minimized
+        while this function is running.
     verbose : int, default=2
         Verbosity level.
         Set to ``0`` to disable print statements, or elevate to a higher number

--- a/echofilter/ui/inference_cli.py
+++ b/echofilter/ui/inference_cli.py
@@ -1023,7 +1023,10 @@ def get_parser():
         help="""
             Hide any Echoview window spawned by this program. If it must use
             an Echoview instance which was already running, that window is not
-            hidden. This is the default behaviour.
+            hidden.
+            Caution: Hiding Echoview has been found to problems when using
+            Echoview 13 and above.
+            For more details, see https://github.com/DeepSenseCA/echofilter/issues/337
         """,
     )
     group_evwin_hiding.add_argument(
@@ -1033,8 +1036,7 @@ def get_parser():
         const="never",
         default=None,
         help="""
-            Don't hide an Echoview window created to run this code. (Disables
-            the default behaviour which is equivalent to ``--hide-echoview``.)
+            Don't hide or minimize an Echoview window created to run this code.
         """,
     )
     group_evwin_hiding.add_argument(
@@ -1046,17 +1048,20 @@ def get_parser():
         help="""
             Hide the Echoview window while this code runs, even if this
             process is utilising an Echoview window which was already open.
+            Caution: Hiding Echoview has been found to problems when using
+            Echoview 13 and above.
+            For more details, see https://github.com/DeepSenseCA/echofilter/issues/337
         """,
     )
     group_evwin.add_argument(
         "--minimize-echoview",
         dest="minimize_echoview",
         action="store_true",
+        default=None,
         help="""
             Minimize any Echoview window used to runs this code while it runs.
             The window will be restored once the program is finished.
-            If this argument is supplied, ``--show-echoview`` is implied unless
-            ``--hide-echoview`` is also given.
+            This is the default behaviour.
         """,
     )
 
@@ -1138,7 +1143,10 @@ def cli(args=None):
         kwargs["offset_surface"] = default_offset
 
     if kwargs["hide_echoview"] is None:
-        kwargs["hide_echoview"] = "never" if kwargs["minimize_echoview"] else "new"
+        kwargs["hide_echoview"] = "never"
+        kwargs["minimize_echoview"] = True
+    elif kwargs["minimize_echoview"] is None:
+        kwargs["minimize_echoview"] = False
 
     if kwargs["verbose"] >= 5:
         import pprint

--- a/echofilter/ui/inference_cli.py
+++ b/echofilter/ui/inference_cli.py
@@ -1140,6 +1140,13 @@ def cli(args=None):
     if kwargs["hide_echoview"] is None:
         kwargs["hide_echoview"] = "never" if kwargs["minimize_echoview"] else "new"
 
+    if kwargs["verbose"] >= 5:
+        import pprint
+
+        print("\nFull list of keyword arguments:")
+        pprint.pprint(kwargs)
+        print("")
+
     from ..inference import run_inference
 
     run_inference(**kwargs)

--- a/echofilter/ui/inference_cli.py
+++ b/echofilter/ui/inference_cli.py
@@ -1114,6 +1114,15 @@ def cli(args=None):
     kwargs["verbose"] -= kwargs.pop("quiet", 0)
 
     if kwargs["verbose"] >= 2:
+        import echofilter.ui.style
+
+        print(
+            echofilter.ui.style.aside_fmt(
+                f"Running Echofilter inference routine, version {__meta__.version}"
+            )
+        )
+
+    if kwargs["verbose"] >= 2:
         parser.print_values()
 
     if kwargs.pop("force"):


### PR DESCRIPTION
- Change the default behaviour to be minimizing Echoview instead of hiding it during inference.
- Show warnings if hiding Echoview is requested during inference.
- Deprecate hiding Echoview during inference.

Note that the default behaviour of ev2csv is unchanged.

Closes #337.