### PR TITLE
 API: Minimize instead of hiding Echoview by default (part 2)

### DIFF
--- a/echofilter/ev2csv.py
+++ b/echofilter/ev2csv.py
@@ -56,8 +56,8 @@ def run_ev2csv(
     keep_ext=False,
     skip_existing=False,
     overwrite_existing=False,
-    minimize_echoview=False,
-    hide_echoview="new",
+    minimize_echoview=True,
+    hide_echoview="never",
     verbose=1,
     dry_run=False,
 ):
@@ -107,16 +107,16 @@ def run_ev2csv(
     overwrite_existing : bool, optional
         Whether to overwrite existing output files. If ``False`` (default), an
         error is raised if the destination file already exists.
-    minimize_echoview : bool, optional
-        If ``True``, the Echoview window being used will be minimized while this
-        function is running. Default is ``False``.
-    hide_echoview : {"never", "new", "always"}, optional
+    minimize_echoview : bool, default=True
+        If ``True`` (default), the Echoview window being used will be minimized
+        while this function is running.
+    hide_echoview : {"never", "new", "always"}, default="never"
         Whether to hide the Echoview window entirely while the code runs.
         If ``hide_echoview="new"``, the application is only hidden if it
         was created by this function, and not if it was already running.
         If ``hide_echoview="always"``, the application is hidden even if it was
         already running. In the latter case, the window will be revealed again
-        when this function is completed. Default is ``"new"``.
+        when this function is completed.
     verbose : int, optional
         Level of verbosity. Default is ``1``.
     dry_run : bool, optional

--- a/echofilter/inference.py
+++ b/echofilter/inference.py
@@ -422,6 +422,11 @@ def run_inference(
         already running. In the latter case, the window will be revealed again
         when this function is completed.
 
+        .. warning::
+            Hiding Echoview has been found to cause problems when using
+            Echoview 13 and above.
+            For more details, see `#337 <https://github.com/DeepSenseCA/echofilter/pull/337>`__.
+
         .. deprecated:: 1.2.1
            Support for hiding echoview during inference will be dropped in a
            future release.

--- a/echofilter/ui/inference_cli.py
+++ b/echofilter/ui/inference_cli.py
@@ -1024,7 +1024,7 @@ def get_parser():
             Hide any Echoview window spawned by this program. If it must use
             an Echoview instance which was already running, that window is not
             hidden.
-            Caution: Hiding Echoview has been found to problems when using
+            Caution: Hiding Echoview has been found to cause problems when using
             Echoview 13 and above.
             For more details, see https://github.com/DeepSenseCA/echofilter/issues/337
         """,
@@ -1048,7 +1048,7 @@ def get_parser():
         help="""
             Hide the Echoview window while this code runs, even if this
             process is utilising an Echoview window which was already open.
-            Caution: Hiding Echoview has been found to problems when using
+            Caution: Hiding Echoview has been found to cause problems when using
             Echoview 13 and above.
             For more details, see https://github.com/DeepSenseCA/echofilter/issues/337
         """,


### PR DESCRIPTION
Follow-up to #338.

- Make ev2csv function match CLI defaults.
- Add warning to run_inference docstring.